### PR TITLE
feat(skill-library): 新增 Exam2Knowledge skill(MIT · 考点逆向)

### DIFF
--- a/skill-library/Exam2Knowledge/LICENSE
+++ b/skill-library/Exam2Knowledge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AtomerCore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skill-library/Exam2Knowledge/SKILL.md
+++ b/skill-library/Exam2Knowledge/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: Exam2Knowledge
+description: >-
+  把考试题目逆向拆解成高频考点与可复用的解题模式(通用解题模板 + Top3 错题库),重在「识别模式 → 套用方法」的应试反射,而非系统性学习;支持单题、批量题、薄弱点三种输入,理科优先。适合刷题、模考、past paper、归纳考点、错题整理、冲刺备考。触发词:刷题, 模考, 考点, 高频题, 错题本, 冲刺, 备考, 题库, 归纳考点; past paper, mock exam.
+---
+# Exam2Knowledge
+
+**Role:** Exam Knowledge Reverse-Engineer. Classify and structure — do NOT solve.
+
+**Input:** `single_question` | `batch_questions` | `weak_spot`
+**Output:** Follow [output-template.md](./assets/output-template.md).
+
+## Pipeline (5 steps)
+
+1. **Pattern Recognition** — subject · type · L1–L6 · hidden intent · signal words
+2. **Tier Knowledge** — `[***]` Must-Master ≥40% / `[**]` Frequent 15-40% / `[*]` Optional <15%
+3. **Build Template** — universal steps + `When X → do Y` rules (≥80% coverage)
+4. **Error Library** — Top 3 pitfalls: `symptom → cause → prevention`
+5. **Batch Intelligence** — (batch only) frequency + clusters + plan
+
+## Load-on-Demand
+
+| Input           | SKILL | Template | References             |
+| --------------- | ----- | -------- | ---------------------- |
+| Quick Q (<50 w) | full  | ✓       | if error/level unclear |
+| Standard Q      | full  | ✓       | if error/level unclear |
+| Batch (≥5)     | full  | ✓       | both required          |
+| Weak spot       | full  | ✓       | diagnostic-rubric      |
+
+## Decision Rules (priority: batch > type)
+
+| Condition  | Action                                  |
+| ---------- | --------------------------------------- |
+| Single Q   | 5 steps                                 |
+| ≥5 Qs     | + batch statistics                      |
+| weak_spot  | Strengthen error analysis               |
+| Image/OCR  | Verify OCR first                        |
+
+
+## Self-Check (1-2 fails → fix inline · 3+ → regenerate)
+
+| Check    | Rule                                                                                |
+| -------- | ----------------------------------------------------------------------------------- |
+| Filled   | All fields or "N/A"                                                                 |
+| Tiers    | `[***]/[**]/[*]` (no ★)                                                          |
+| Time     | 1-2 min recall, 3-5 min apply                                                       |
+| Depth    | Surface verb ≠ Hidden verb (see[blooms-taxonomy.md](./references/blooms-taxonomy.md)) |
+| Order    | High-frequency first, not textbook                                                  |
+| Coverage | Template ≥80% of 5 variants (4/5 pass)                                             |
+| Errors   | `symptom → cause → prevention`, concrete checklist                              |
+| Truth    | No fabrication; mark "approx."                                                      |
+
+## Top 3 Errors (3D: A frequency + B severity + C preventability, 1-3 each)
+
+| Dim         | 1       | 2          | 3                  |
+| ----------- | ------- | ---------- | ------------------ |
+| **A** | Rare    | Occasional | Dominant           |
+| **B** | 1-2 pts | 3-5 pts    | Full Q / cascade   |
+| **C** | Insight | Partial    | Fully templateable |
+
+Tie-break: C > A. Pick top 3. Output: `symptom → cause → prevention` (concrete checklist).
+
+## Positive Directives
+
+- Order by **exam frequency**, not textbook
+- `[***] / [**] / [*]` consistent · `→` for cause-effect
+- Hidden intent **deeper** than surface
+- Template ≥80% · Errors **actionable** · Time budget mandatory
+- Bullets/tables > prose · **Supplement** study, not replace · No fabrication
+
+## Limitations (do NOT use)
+
+- Open-ended essays / writing prompts
+- Live exam proctoring
+- Subjects outside STEM + basic humanities
+- Source images with unclear OCR
+- Single factual lookup · User wants the actual answer
+
+**Caveat:** Tiers reflect common patterns, not guaranteed outcomes. Cross-check with official syllabus.
+
+## File Map
+
+| File                                                   | Purpose              | Load                   |
+| ------------------------------------------------------ | -------------------- | ---------------------- |
+| [SKILL.md](./SKILL.md)                                    | Pipeline + rules     | Always                 |
+| [output-template.md](./assets/output-template.md)         | Output structure     | When generating        |
+| [blooms-taxonomy.md](./references/blooms-taxonomy.md)     | L1-L6 levels         | When classifying level |
+| [diagnostic-rubric.md](./references/diagnostic-rubric.md) | 5 error categories   | When building errors   |
+| [quantified-rubric.md](./references/quantified-rubric.md) | Quantified standards | When self-checking     |

--- a/skill-library/Exam2Knowledge/assets/output-template.md
+++ b/skill-library/Exam2Knowledge/assets/output-template.md
@@ -1,0 +1,35 @@
+# Output Template
+
+3 core modules + 1 batch section (batch_questions only).
+
+## 1. Metadata
+
+- **Subject / Type / Difficulty:** ___
+- **Level:** L1–L6    **Time:** ___ min
+- **Pattern:** ___
+
+## 2. Knowledge (Tiered)
+
+- `[***]` Must-Master: concept + formula + use + pitfall
+- `[**]` Frequent: brief
+- `[*]` Optional: brief (omit if N/A)
+
+## 3. Solution & Errors
+
+**Steps:** 1.___ 2.___ 3.___
+**Rules:** When X → do Y
+**Top 3 Errors** (`symptom → cause → prevention`):
+
+- E1: ___  E2: ___  E3: ___
+
+## 4. Batch (batch only)
+
+- **Top 5:** freq ranking
+- **Clusters:** co-tested topics
+- **Plan:** Phase 1/2/3
+
+## Constraints
+
+1. All fields filled or "N/A"
+2. Tiers `[***]/[**]/[*]` (no ★) · `→` for cause-effect
+3. No "..." · Time budget mandatory

--- a/skill-library/Exam2Knowledge/references/blooms-taxonomy.md
+++ b/skill-library/Exam2Knowledge/references/blooms-taxonomy.md
@@ -1,0 +1,55 @@
+# Bloom's Taxonomy
+
+6-level hierarchy. Load when classifying L1–L6 or checking "hidden intent" depth.
+
+## Levels
+
+| L  | Name       | Verbs                                                     | Example                                |
+| -- | ---------- | --------------------------------------------------------- | -------------------------------------- |
+| L1 | Remember   | recall, identify, list, name, state, define               | "State the quadratic formula."         |
+| L2 | Understand | explain, describe, summarize, paraphrase, classify        | "Why is division by zero undefined?"   |
+| L3 | Apply      | compute, solve, apply, execute, demonstrate, use          | "Solve 2x² - 5x + 3 = 0."             |
+| L4 | Analyze    | analyze, compare, contrast, distinguish, examine          | "Is f(x) increasing on (-1, 2)?"       |
+| L5 | Evaluate   | evaluate, critique, justify, argue, defend, assess        | "Evaluate this regression's validity." |
+| L6 | Create     | design, propose, create, construct, formulate, synthesize | "Design an experiment to measure g."   |
+
+**Default:** L3. **Tie:** higher.
+
+## Fuzzy Tie-Breakers
+
+| Stem                       | Default | Why               |
+| -------------------------- | ------- | ----------------- |
+| "Show that" / "证明"       | L4      | Logical chain     |
+| "Determine" (method given) | L3      | Prescribed        |
+| "Determine" (no method)    | L4      | Choose method     |
+| "Find" (single)            | L3      | Direct compute    |
+| "Find all" / "求所有"      | L4      | Enumerate + edges |
+| "Compare … and …"        | L4      | Multi-attribute   |
+| "Which is better"          | L5      | Needs criteria    |
+| "Prove or disprove"        | L5      | Defend claim      |
+| "Use … to solve"          | L3      | Tool prescribed   |
+| "If …, then …" (predict) | L4      | Conditional       |
+| "Why" (open)               | L5      | Argument          |
+| "How" (procedure)          | L3      | Procedural        |
+| "How" (mechanism)          | L2      | Explanation       |
+
+**Trap:** "Discuss" / "论述" sounds L4 but often masks L5 (take a side).
+
+## Chinese Verbs
+
+| Verb                               | Level |
+| ---------------------------------- | ----- |
+| 记住、列举、写出、复述             | L1    |
+| 解释、说明、描述、概括             | L2    |
+| 计算、求解、应用、证明(方法已知)   | L3    |
+| 分析、比较、讨论(无立场)           | L4    |
+| 评价、批判、论证、证明(需自选方法) | L5    |
+| 设计、构造、提出、推广             | L6    |
+
+**Rules:** translate first → "说明"=L2 not L3. Bilingual stems: use majority-language list; translated Qs often simplify verbs upward — re-elevate one level. Multi-part: per part; dominant level drives `[***]/[**]`.
+
+## Decision Tree
+
+`verb → Quick Picker → Tie? → Fuzzy Rules → Still tied? → Higher → Bilingual? → Final L1-L6`
+
+**Output:** record both surface verb and hidden level. They must differ for "deeper" check.

--- a/skill-library/Exam2Knowledge/references/diagnostic-rubric.md
+++ b/skill-library/Exam2Knowledge/references/diagnostic-rubric.md
@@ -1,0 +1,40 @@
+# Error Diagnostic Rubric
+
+5-category mistake classification. Load when building error library or picking Top 3.
+
+## Decision Flow
+
+```
+Wrong answer?
+  → Misread what's asked?           → C1 Reading
+  → Wrong concept/definition?       → C2 Conceptual
+  → Wrong method/sequence?          → C3 Procedural
+  → Mechanical slip (sign, math)?   → C4 Execution
+  → Missed constraint/edge case?    → C5 Edge Case
+```
+
+**Tie:** pick upstream (C2 conceptual usually shows as C4 — fix concept, not sign).
+**Multi-tag:** tag all, score with 3D (see [quantified-rubric.md](./quantified-rubric.md)).
+
+## Categories
+
+| ID | Type       | Signal                 | Prevention                                      |
+| -- | ---------- | ---------------------- | ----------------------------------------------- |
+| C1 | Reading    | "Misread the question" | Re-read 30s; highlight NOT, EXCEPT, 除非        |
+| C2 | Conceptual | "Wrong idea/model"     | Verify definition + preconditions               |
+| C3 | Procedural | "Wrong method"         | Checklist steps; verify preconditions           |
+| C4 | Execution  | "Calculation mistake"  | Scan signs; re-do from error point              |
+| C5 | Edge Case  | "Missed special case"  | Substitute answer; check domain, boundary, unit |
+
+## Domain Patterns
+
+All subjects share the same 5-category framework. Differences live in **dominant C-tag** and **typical traps**.
+
+| Domain                                                  | Dominant | Typical trap (illustrative)                         |
+| ------------------------------------------------------- | -------- | --------------------------------------------------- |
+| **STEM** (math, physics, chem, bio, CS, stats)    | C2 / C4  | Wrong method (C3), sign slip (C4), missed edge (C5) |
+| **Humanities** (history, geo, politics, language) | C1 / C2  | Off-topic (C1), anachronism (C2), no evidence (C3)  |
+
+**Usage:** Identify domain → pick dominant C-tag → list 1–3 traps specific to the current question. 3D scoring (A+B+C) ranks Top 3.
+
+**Hypothesize, don't lookup:** generate traps from the question itself. If a trap is unclear, the analysis isn't deep enough — rewrite it.

--- a/skill-library/Exam2Knowledge/references/quantified-rubric.md
+++ b/skill-library/Exam2Knowledge/references/quantified-rubric.md
@@ -1,0 +1,58 @@
+# Quantified Rubric
+
+Detailed standards for [SKILL.md](../SKILL.md) Self-Check. Load only when self-validating.
+
+## 1. Surface vs. Hidden Intent
+
+| Term               | Definition                                   | Example                                         |
+| ------------------ | -------------------------------------------- | ----------------------------------------------- |
+| **Surface**  | Verb (and object) in stem                    | "Solve 2x² - 5x + 3 = 0" →*solve quadratic* |
+| **Hidden**   | Underlying concept/method; Bloom L1–L6 verb | *apply quadratic formula (L3)*                |
+| **"Deeper"** | Surface ≠ Hidden verb/level                 | "prove" + "apply induction" → ✅               |
+
+**Failure:** surface = hidden = "solve" → rewrite to expose method layer.
+
+## 2. Tier Scoring
+
+Order by **exam frequency**, not textbook.
+
+| Tier        | Marker    | Meaning                       | Slot               |
+| ----------- | --------- | ----------------------------- | ------------------ |
+| Must-Master | `[***]` | ≥40% papers, 5+ pts loss     | 1–3               |
+| Frequent    | `[**]`  | 15–40% papers, 2–4 pts loss | 2–4               |
+| Optional    | `[*]`   | <15%, niche/extension         | 0–2 (omit if N/A) |
+
+**Rule:** 1–3 `[***]` per question. Omit `[*]` if it dilutes focus.
+
+## 3. ≥80% Template Coverage
+
+A template is "good" if steps apply unchanged to ≥80% of variants. **Test:** enumerate 5 variants → apply literally → count.
+
+| Pass  | Verdict   | Action              |
+| ----- | --------- | ------------------- |
+| 5/5   | Excellent | Keep                |
+| 4/5   | Pass      | Mark edge case      |
+| 3/5   | Fail      | Generalize one step |
+| ≤2/5 | Hard fail | Re-architect        |
+
+## 4. 3D Error Scoring
+
+Top 3 by `A + B + C` (each 1–3, max 9).
+
+| Dim                         | 1 (low)       | 2 (mid)                | 3 (high)                                          |
+| --------------------------- | ------------- | ---------------------- | ------------------------------------------------- |
+| **A. Frequency**      | Rare          | Occasional             | Dominant trap                                     |
+| **B. Severity**       | 1–2 pts      | 3–5 pts               | Full Q / cascade                                  |
+| **C. Preventability** | Needs insight | Partially templateable | Fully templateable (checklist → 100% prevention) |
+
+**Tie-break:** C > A. **Output:** `symptom → cause → prevention` — prevention = **concrete checklist item**, not advice.
+
+## 5. Self-Check Thresholds
+
+| Fails | Action                     |
+| ----- | -------------------------- |
+| 0     | Ship                       |
+| 1–2  | Fix inline, re-run         |
+| ≥3   | Regenerate section, re-run |
+
+**No skip:** run before delivery.

--- a/skill-library/README.md
+++ b/skill-library/README.md
@@ -43,6 +43,12 @@ Inno Agent Skill 集合整理 —— 每个 Skill 是独立目录，可直接下
 | [edu-solid-geometry](./edu-solid-geometry/) | 收集 | 立体几何题 → Three.js 交互 3D 解题页 | [wy51ai/edulab](https://github.com/wy51ai/edulab/tree/master/skills/edu-solid-geometry) | [demo](./assets/edu-solid-geometry/demo.gif) |
 | [edu-analytic-geometry](./edu-analytic-geometry/) | 收集 | 圆锥曲线题 → Canvas 2D 动态画板 | [wy51ai/edulab](https://github.com/wy51ai/edulab/tree/master/skills/edu-analytic-geometry) | [demo](./assets/edu-analytic-geometry/demo.gif) |
 
+### 📚 教育 · 备考与刷题
+
+| Skill | 类型 | 通过验证 | 一句话 | 引用 |
+|---|---|---|---|---|
+| [Exam2Knowledge](./Exam2Knowledge/) | 收集 |  | 把考题逆向拆成高频考点、解题模板与错题库，构建应试模式识别（理科优先） | [AtomerCore/Exam2Knowledge-skill](https://github.com/AtomerCore/Exam2Knowledge-skill) |
+
 ### 📄 文档 · 办公与转换
 
 | Skill | 类型 | 一句话 | 引用 |


### PR DESCRIPTION
## 概述

新增 **Exam2Knowledge**(来自 [AtomerCore/Exam2Knowledge-skill](https://github.com/AtomerCore/Exam2Knowledge-skill),**MIT** 授权)到 `skill-library/`。

## 这个 skill 做什么

把考试题目**逆向拆解**为应试知识体系:
- **高频考点**分档(`[***]` 必掌握 / `[**]` 高频 / `[*]` 可选)
- **可复用解题模板**(通用步骤 + `When X → do Y` 规则)
- **Top3 错题库**(症状 → 成因 → 预防)
- 支持单题 / 批量 / 薄弱点三种输入,理科优先。重在「识别模式 → 套用方法」的应试反射,不做系统教学。

## 对齐

- 扁平目录、`SKILL.md` 带**中文 description**(触发词内联)、无 `meta.yaml`、随包保留 **MIT LICENSE**(去掉了 frontmatter 的 `version` 字段)。
- 新组 **「📚 教育 · 备考与刷题」**,带「通过验证」列(本批暂留空)。

## 说明

- README 改动**纯新增**;`SKILL.md` 正文保持英文,description 为中文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
