### PR TITLE
feat(skill-library): 新增教案与教学设计 5 个 Skill

### DIFF
--- a/skill-library/README.md
+++ b/skill-library/README.md
@@ -51,6 +51,16 @@ Inno Agent Skill 集合整理 —— 每个 Skill 是独立目录，可直接下
 |---|---|---|---|---|
 | [Exam2Knowledge](./Exam2Knowledge/) | 收集 |  | 把考题逆向拆成高频考点、解题模板与错题库，构建应试模式识别（理科优先） | [AtomerCore/Exam2Knowledge-skill](https://github.com/AtomerCore/Exam2Knowledge-skill) |
 
+### 🧑‍🏫 教育 · 教案与教学设计
+
+| Skill | 类型 | 通过验证 | 一句话 | 引用 |
+|---|---|---|---|---|
+| [backwards-design-unit-planner](./backwards-design-unit-planner/) | 收集 |  | 逆向设计（UbD）：从学习成果倒推评估证据与学习活动，产出完整单元教学计划 | [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/backwards-design-unit-planner) |
+| [scope-and-sequence-designer](./scope-and-sequence-designer/) | 收集 |  | 课程范围与进度：跨年级/学期的纵向进阶与横向衔接，带先修依赖与连贯性检查 | [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/scope-and-sequence-designer) |
+| [explicit-instruction-sequence-builder](./explicit-instruction-sequence-builder/) | 收集 |  | 显性教学课时序列（I Do/We Do/You Do），含理解检查点与时间分配的可上课教案 | [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills/tree/main/skills/explicit-instruction/explicit-instruction-sequence-builder) |
+| [differentiation-adapter](./differentiation-adapter/) | 收集 |  | 同一任务按学困/超常/多动/读写障碍等差异化适配，保持学习目标不变 | [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/differentiation-adapter) |
+| [formative-assessment-technique-selector](./formative-assessment-technique-selector/) | 收集 |  | 按教学时刻挑随堂检测/形成性评估技术，含实施步骤与学生应答解读 | [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/formative-assessment-technique-selector) |
+
 ### 🧑‍🏫 教育 · 教师与批改
 
 | Skill | 类型 | 通过验证 | 一句话 | 引用 |

--- a/skill-library/backwards-design-unit-planner/SKILL.md
+++ b/skill-library/backwards-design-unit-planner/SKILL.md
@@ -1,0 +1,322 @@
+---
+# AGENT SKILLS STANDARD FIELDS (v2)
+name: backwards-design-unit-planner
+category: 教学辅导
+description: >-
+  用 Wiggins & McTighe 的逆向设计(UbD)规划教学单元:从期望学习成果 → 评估证据 → 学习活动三阶段倒推,产出含大概念/基本问题、评估蓝图、WHERETO 教学序列与对齐自检的完整单元计划。开一个新单元或按课程标准重构旧单元时使用。触发词:设计单元, 单元教学设计, 大单元设计, 逆向设计, UbD, 备一个单元, 教学目标对齐, 单元规划; unit plan, backwards design, understanding by design.
+disable-model-invocation: false
+user-invocable: true
+effort: medium
+
+# EXISTING FIELDS
+
+skill_id: "curriculum-assessment/backwards-design-unit-planner"
+skill_name: "Backwards Design Unit Planner"
+domain: "curriculum-assessment"
+version: "1.0"
+evidence_strength: "strong"
+evidence_sources:
+  - "Wiggins & McTighe (1998, 2005) — Understanding by Design"
+  - "Wiggins & McTighe (2011) — The Understanding by Design Guide to Creating High-Quality Units"
+  - "Tomlinson & McTighe (2006) — Integrating Differentiated Instruction and Understanding by Design"
+  - "Hattie (2009) — Visible Learning: backward design and clarity of learning intentions"
+  - "Biggs & Tang (2011) — Teaching for Quality Learning at University: constructive alignment"
+input_schema:
+  required:
+    - field: "desired_outcomes"
+      type: "string"
+      description: "What students should understand, know, and be able to do by the end of the unit"
+    - field: "student_level"
+      type: "string"
+      description: "Age/year group"
+    - field: "unit_duration"
+      type: "string"
+      description: "Number of lessons or weeks"
+  optional:
+    - field: "subject_area"
+      type: "string"
+      description: "The curriculum subject"
+    - field: "curriculum_framework"
+      type: "string"
+      description: "From context engine: specific curriculum standards to address"
+    - field: "student_profiles"
+      type: "array"
+      description: "From context engine: prior attainment, known gaps, class composition"
+    - field: "available_resources"
+      type: "string"
+      description: "Key texts, materials, or resources available"
+output_schema:
+  type: "object"
+  fields:
+    - field: "stage_1_desired_results"
+      type: "object"
+      description: "Enduring understandings, essential questions, knowledge and skills"
+    - field: "stage_2_assessment_evidence"
+      type: "object"
+      description: "Performance tasks and other evidence that will demonstrate understanding"
+    - field: "stage_3_learning_plan"
+      type: "object"
+      description: "Sequenced learning activities aligned to stages 1 and 2"
+    - field: "alignment_check"
+      type: "string"
+      description: "Verification that activities, assessments, and outcomes are aligned"
+chains_well_with:
+  - "competency-unpacker"
+  - "criterion-referenced-rubric-generator"
+  - "formative-assessment-technique-selector"
+  - "explicit-instruction-sequence-builder"
+  - "curriculum-knowledge-architecture-designer"
+  - "kud-knowledge-type-mapper"
+  - "critical-thinking-task-designer"
+  - "scope-and-sequence-designer"
+teacher_time: "5 minutes"
+tags: ["UbD", "backwards-design", "unit-planning", "curriculum", "alignment"]
+---
+
+# Backwards Design Unit Planner
+
+## What This Skill Does
+
+Generates a complete Stage 1–2–3 Understanding by Design unit structure from a teacher's desired outcomes: Stage 1 defines enduring understandings, essential questions, and target knowledge/skills; Stage 2 designs the assessment evidence that will demonstrate understanding (before any activities are planned); Stage 3 sequences the learning activities that build toward the assessments and outcomes. The critical insight of backwards design is that assessment is designed BEFORE instruction — not as an afterthought but as the definition of what success looks like. AI is specifically valuable here because backwards design requires holding all three stages in mind simultaneously and ensuring tight alignment between them — what is assessed must match what is intended, and what is taught must prepare students for what is assessed. Most teacher-designed units plan activities first and assessments last, which produces misalignment.
+
+## Evidence Foundation
+
+Wiggins & McTighe (1998, 2005) developed Understanding by Design (UbD), the most widely adopted curriculum design framework in education. The framework's central argument is that curriculum should be designed backward from desired results, not forward from available activities. Stage 1 (Desired Results) defines what students should understand — not just know or do, but genuinely understand at a transferable level. Stage 2 (Assessment Evidence) determines what evidence would demonstrate that understanding — designed before instruction so that teaching targets real outcomes, not just coverage. Stage 3 (Learning Plan) sequences the instruction needed to build toward the assessed outcomes. Wiggins & McTighe (2011) provided practical guidance for unit creation, emphasising that enduring understandings should be transferable ideas worth understanding beyond the unit, and essential questions should be genuinely open — questions that provoke inquiry rather than have predetermined answers. Biggs & Tang (2011) developed "constructive alignment" — the principle that learning outcomes, assessment tasks, and teaching activities must be aligned so that what is assessed is what is taught and what is taught prepares for what is assessed. Hattie (2009) confirmed that clarity of learning intentions and success criteria is one of the highest-leverage factors in student achievement.
+
+## Input Schema
+
+The teacher must provide:
+- **Desired outcomes:** What students should understand, know, and be able to do. *e.g. "Students will understand how organisms adapt to their environments through natural selection, know key vocabulary (adaptation, variation, natural selection, evolution), and be able to explain how a specific organism's traits relate to its environment."*
+- **Student level:** Year group. *e.g. "Year 9"*
+- **Unit duration:** Length of the unit. *e.g. "6 lessons (1 hour each)" / "3 weeks"*
+
+Optional (injected by context engine if available):
+- **Subject area:** The curriculum subject
+- **Curriculum framework:** Specific standards
+- **Student profiles:** Prior attainment, known gaps
+- **Available resources:** Texts, materials, resources
+
+## Prompt
+
+```
+You are an expert in curriculum design, with deep knowledge of Wiggins & McTighe's (1998, 2005) Understanding by Design framework, Biggs & Tang's (2011) constructive alignment, and Hattie's (2009) research on learning intentions and success criteria. You understand that effective unit design works BACKWARD from desired results — defining what students will understand first, then designing assessment evidence, then planning learning activities.
+
+Your task is to design a UbD unit for:
+
+**Desired outcomes:** {{desired_outcomes}}
+**Student level:** {{student_level}}
+**Unit duration:** {{unit_duration}}
+
+The following optional context may or may not be provided. Use whatever is available; ignore any fields marked "not provided."
+
+**Subject area:** {{subject_area}} — if not provided, infer from the desired outcomes.
+**Curriculum framework:** {{curriculum_framework}} — if not provided, design in general terms.
+**Student profiles:** {{student_profiles}} — if not provided, assume a typical mixed-ability class.
+**Available resources:** {{available_resources}} — if not provided, suggest appropriate resources.
+
+Apply these evidence-based principles:
+
+1. **Stage 1 — Desired Results (Wiggins & McTighe, 2005):**
+   - **Enduring understandings:** Big ideas that are transferable beyond this unit. These are not facts to memorise but principles to understand. Frame as "Students will understand that..." statements.
+   - **Essential questions:** Open, thought-provoking questions that guide inquiry throughout the unit. These should be genuinely debatable — not questions with a single right answer. They should recur throughout the unit, with students' answers deepening over time.
+   - **Knowledge:** Specific facts, concepts, and vocabulary students will know.
+   - **Skills:** Specific abilities students will be able to demonstrate.
+
+2. **Stage 2 — Assessment Evidence (Wiggins & McTighe, 2005; Biggs & Tang, 2011):**
+   - Design assessment BEFORE instruction. This is the core UbD principle.
+   - **Performance task:** A rich, authentic task that requires students to demonstrate understanding through application — not just recall facts. The task should require transfer — applying learning to a new situation.
+   - **Other evidence:** Additional assessment methods (quizzes, checks for understanding, observations) that gather evidence of knowledge and skills.
+   - Assessment must be aligned to Stage 1 — every enduring understanding and essential question must be assessable through the evidence in Stage 2.
+
+3. **Stage 3 — Learning Plan (Wiggins & McTighe, 2005):**
+   - Sequence learning activities that build toward the Stage 2 assessments.
+   - Use the WHERETO framework: Where are we going? Hook the student. Explore and equip. Rethink and revise. Evaluate. Tailor to individual needs. Organise for understanding.
+   - Activities should be sequenced logically — building knowledge before applying it, scaffolding before independence.
+   - Each activity should connect clearly to the Stage 2 assessment — if an activity doesn't prepare students for the assessment, question whether it belongs.
+
+4. **Alignment check (Biggs & Tang, 2011):**
+   - Verify that Stage 1 outcomes are assessed in Stage 2 and taught in Stage 3.
+   - Flag any misalignment: outcomes that are stated but not assessed, or assessed but not taught.
+
+Return your output in this exact format:
+
+## Unit Plan: [Unit Title]
+
+**For:** [Student level]
+**Subject:** [Subject area]
+**Duration:** [Unit duration]
+
+### Stage 1: Desired Results
+
+**Enduring Understandings**
+[2–3 transferable understandings — "Students will understand that..."]
+
+**Essential Questions**
+[2–3 open, recurring questions that guide inquiry]
+
+**Students will know:**
+[Specific knowledge — facts, concepts, vocabulary]
+
+**Students will be able to:**
+[Specific skills]
+
+### Stage 2: Assessment Evidence
+
+**Performance Task**
+[Description of the authentic assessment task, including: the scenario, what students produce, what the task assesses, and brief success criteria]
+
+**Other Evidence**
+[Additional assessment methods mapped to specific Stage 1 outcomes]
+
+### Stage 3: Learning Plan
+
+[Lesson-by-lesson or phase-by-phase sequence, showing: what happens, what it builds toward, and how it connects to Stage 2]
+
+### Alignment Check
+
+[Verification that all Stage 1 outcomes are assessed in Stage 2 and addressed in Stage 3. Flag any gaps.]
+
+**Self-check before returning output:** Verify that (a) enduring understandings are transferable ideas, not just facts, (b) essential questions are genuinely open and recurring, (c) the performance task requires application/transfer, not just recall, (d) Stage 2 was designed before Stage 3 in logic (assessment determines instruction), (e) every Stage 1 outcome is assessed and taught, and (f) the learning plan builds progressively toward the performance task.
+```
+
+## Example Output
+
+**Scenario:** *Desired outcomes: "Students will understand how natural selection drives adaptation in organisms, know key concepts (adaptation, variation, inheritance, natural selection, evolution), and be able to explain how specific organisms' traits are suited to their environment and how populations change over time." / Student level: "Year 9" / Unit duration: "8 lessons (50 minutes each)" / Subject area: "Science (Biology)"*
+
+---
+
+## Unit Plan: Natural Selection and Adaptation
+
+**For:** Year 9
+**Subject:** Science (Biology)
+**Duration:** 8 lessons (50 minutes each)
+
+### Stage 1: Desired Results
+
+**Enduring Understandings**
+1. Students will understand that **organisms with traits better suited to their environment are more likely to survive and reproduce, and these traits are passed to offspring — leading to populations that change over time.** (This is the mechanism of natural selection.)
+2. Students will understand that **variation within a population is essential for natural selection — without variation, there is nothing for the environment to "select."**
+3. Students will understand that **adaptation is a result of natural selection over many generations, not a deliberate choice by individual organisms.** (Organisms do not choose to adapt; populations change because better-suited individuals leave more offspring.)
+
+**Essential Questions**
+1. "Why do organisms look the way they do?" (Recurring — answers deepen from "because they adapted" in Lesson 1 to "because natural selection favoured traits that increased survival and reproduction in their specific environment" by Lesson 8.)
+2. "If the environment changes, what happens to organisms that are well-adapted to the old environment?" (Drives the understanding that adaptation is not permanent — it is context-dependent.)
+3. "Why is variation important?" (Connects genetics to evolution — without variation, natural selection cannot operate.)
+
+**Students will know:**
+- The definitions of adaptation, variation, inheritance, natural selection, evolution, and species
+- Examples of structural, behavioural, and functional adaptations in named organisms
+- That variation arises from genetic differences (and sometimes environmental factors)
+- The four conditions required for natural selection: variation, inheritance, selection pressure, differential reproduction
+- Darwin's contribution to the theory of evolution by natural selection
+
+**Students will be able to:**
+- Explain how a named organism's specific traits help it survive in its environment
+- Describe the process of natural selection step by step
+- Predict what might happen to a population if the environment changes
+- Distinguish between Lamarckian (acquired characteristics) and Darwinian (natural selection) explanations — and explain why Lamarck's is incorrect
+
+### Stage 2: Assessment Evidence
+
+**Performance Task: "The Island"**
+
+*Scenario:* "A population of beetles lives on a volcanic island. The beetles vary in colour from green to brown. The island is covered in green vegetation. Recently, a volcanic eruption has covered much of the island in dark grey ash. Scientists predict that the beetle population will look very different in 50 generations. Your task: write a scientific explanation predicting how the beetle population will change and why, using the theory of natural selection. Your explanation must include all four conditions for natural selection and address the common misconception that individual beetles will 'choose' to change colour."
+
+*What students produce:* A 200–300 word scientific explanation.
+
+*What the task assesses:*
+- Enduring Understanding 1: mechanism of natural selection (can they explain the process correctly?)
+- Enduring Understanding 2: role of variation (do they identify existing colour variation as essential?)
+- Enduring Understanding 3: adaptation is not a choice (do they explain that the population changes, not individual beetles?)
+- Essential Questions 1 and 2: adapted organisms + environmental change
+- Knowledge: four conditions, correct terminology
+- Skills: step-by-step explanation, distinguishing Darwinian from Lamarckian reasoning
+
+*Brief success criteria:*
+- Identifies existing variation in the population (colour range)
+- Explains selection pressure (darker beetles better camouflaged on ash)
+- Describes differential survival and reproduction
+- Explains inheritance of traits to offspring
+- Predicts population change over generations
+- Addresses the misconception that beetles "choose" to change colour
+
+**Other Evidence**
+
+| Lesson | Assessment | Stage 1 outcome assessed |
+|--------|-----------|------------------------|
+| 2 | Exit ticket: "Name 3 adaptations of a polar bear and explain how each helps it survive" | Knowledge (adaptations); Skill (explaining trait–environment link) |
+| 4 | Mini-whiteboard hinge question: "A giraffe stretches its neck to reach leaves. Its offspring are born with longer necks. Is this Darwinian or Lamarckian? Why?" | Understanding 3 (adaptation is not a choice); Knowledge (Lamarck vs Darwin) |
+| 6 | Peer explanation: students explain natural selection to a partner using a new example; partner checks against a 4-step checklist | Knowledge (four conditions); Skill (step-by-step explanation) |
+
+### Stage 3: Learning Plan
+
+**Lesson 1 — Hook and Explore: "Why Do Organisms Look the Way They Do?"**
+- Show 5 images of unusual adaptations (anglerfish, cactus, arctic fox, chameleon, deep-sea tube worm). Students discuss: "Why does this organism look like this? What problem does this trait solve?"
+- Introduce Essential Question 1. Students write initial answers.
+- Define "adaptation" — structural, behavioural, functional. Students classify the 5 examples.
+- *Builds toward:* Stage 2 performance task (explaining trait–environment link).
+
+**Lesson 2 — Equip: Types of Adaptation**
+- Detailed study of 3 organisms and their adaptations (one structural, one behavioural, one functional).
+- Students explain in writing: "How does [trait] help [organism] survive in [environment]?"
+- *Exit ticket assessment.*
+- *Builds toward:* Stage 2 performance task (explaining how traits suit environments).
+
+**Lesson 3 — Explore: Variation**
+- Practical: measuring variation in a population (e.g., hand span, leaf size, or simulated beetle data).
+- Key concept: variation exists within every population. Some variation is genetic.
+- Introduce Essential Question 3: "Why is variation important?"
+- *Builds toward:* Enduring Understanding 2 (variation is essential for natural selection).
+
+**Lesson 4 — Equip: Natural Selection Step by Step**
+- Explicit instruction: the 4 conditions for natural selection (variation, inheritance, selection pressure, differential reproduction).
+- Use the peppered moth as a worked example — model the explanation step by step.
+- Introduce Lamarck vs. Darwin distinction. Common misconception: "the giraffe stretched its neck."
+- *Hinge question assessment.*
+- *Builds toward:* Performance task (students must use the 4 conditions).
+
+**Lesson 5 — Explore and Rethink: Simulation**
+- Simulation activity: "Survival of the Fittest" using coloured paper "organisms" on different backgrounds. Students observe which are "eaten" (selected against) and which survive. Repeat for 3 "generations."
+- Students observe that the population changes over time — without any individual changing.
+- Revisit Essential Question 1: update answers.
+- *Builds toward:* Enduring Understanding 3 (populations change, not individuals).
+
+**Lesson 6 — Equip and Evaluate: Practice Explanations**
+- Students practise writing natural selection explanations using a new example (e.g., antibiotic resistance in bacteria).
+- Peer assessment using the 4-step checklist from the performance task criteria.
+- Teacher circulates and identifies common errors for whole-class feedback.
+- *Builds toward:* Performance task (practising the exact skill assessed).
+
+**Lesson 7 — Performance Task: "The Island"**
+- Students complete the performance task under supported conditions.
+- Sentence starters available for EAL students. Word bank available for all students (may be removed for extension students).
+- Teacher circulates, noting common misconceptions for Lesson 8 feedback.
+
+**Lesson 8 — Rethink and Extend: Feedback and Transfer**
+- Return marked work with targeted feedback.
+- Whole-class review of most common errors (especially Lamarckian reasoning).
+- Extension: "Humans have been using antibiotics for about 80 years. Bacteria are becoming resistant. Use natural selection to explain why."
+- Revisit all three Essential Questions: students write final answers and compare with Lesson 1 answers.
+
+### Alignment Check
+
+| Stage 1 Outcome | Assessed in Stage 2? | Taught in Stage 3? | Aligned? |
+|-----------------|---------------------|--------------------|---------|
+| Understanding 1 (natural selection mechanism) | Performance task + Lesson 6 peer assessment | Lessons 4, 5, 6 | ✓ |
+| Understanding 2 (variation is essential) | Performance task | Lesson 3 | ✓ |
+| Understanding 3 (adaptation is not a choice) | Performance task + Lesson 4 hinge question | Lessons 4, 5 | ✓ |
+| Knowledge (key vocabulary) | All assessments require terminology | Introduced progressively across Lessons 1–4 | ✓ |
+| Skill (explain trait–environment link) | Lesson 2 exit ticket + performance task | Lessons 1, 2 | ✓ |
+| Skill (step-by-step explanation) | Performance task + Lesson 6 peer check | Lessons 4, 6 (modelled and practised) | ✓ |
+
+No misalignment detected. All Stage 1 outcomes are assessed and taught.
+
+---
+
+## Known Limitations
+
+1. **The unit plan provides structure, not detailed lesson plans.** Each lesson entry describes the key activity and its purpose but does not include full timing, differentiation, resources, or teacher scripts. Teachers should use the Stage 3 sequence as a framework and develop detailed lesson plans using other skills (Explicit Instruction Sequence Builder, Lesson Opening Designer, etc.).
+
+2. **Backwards design assumes clear desired outcomes.** If the teacher's initial outcome statement is vague ("students will learn about natural selection"), the UbD structure will be less precise. The quality of the unit depends on the specificity of the input. Chain with Competency Unpacker if the outcome needs clarifying before unit design.
+
+3. **The performance task is designed for a specific context and may need adaptation.** The "Island" scenario works for this Biology topic but may not transfer directly to other schools' resources or assessment requirements. Teachers should review the performance task against their specific assessment framework and modify the scenario while maintaining the assessment design principles.

--- a/skill-library/differentiation-adapter/SKILL.md
+++ b/skill-library/differentiation-adapter/SKILL.md
@@ -1,0 +1,242 @@
+---
+# AGENT SKILLS STANDARD FIELDS (v2)
+name: differentiation-adapter
+category: 教学辅导
+description: >-
+  把同一堂课的任务按不同学习者需求做差异化适配,同时保持核心学习目标不变:为学困、超常、注意力障碍(ADHD)、读写障碍、焦虑或二语(EAL)学生调整难度入口与支架,输出改了什么、保留了什么、目标核验与实施建议(明确排斥已被证伪的“学习风格”理论)。同一份教案要照顾不同层次学生时使用。触发词:分层教学, 差异化教学, 因材施教, 照顾不同层次, 学困生辅导, 分层作业, 分层任务, 个别化调整; differentiation, adapt task, SEND, EAL, scaffolding.
+disable-model-invocation: false
+user-invocable: true
+effort: medium
+
+# EXISTING FIELDS
+
+skill_id: "curriculum-assessment/differentiation-adapter"
+skill_name: "Differentiation Adapter"
+domain: "curriculum-assessment"
+version: "1.0"
+evidence_strength: "moderate"
+evidence_sources:
+  - "Tomlinson (2001, 2014) — How to Differentiate Instruction in Academically Diverse Classrooms"
+  - "Rose & Meyer (2002) — Teaching Every Student in the Digital Age: Universal Design for Learning"
+  - "Vygotsky (1978) — Mind in Society: the zone of proximal development"
+  - "Hattie (2009) — Visible Learning: differentiation and responsive teaching"
+  - "CAST (2018) — Universal Design for Learning Guidelines version 2.2"
+input_schema:
+  required:
+    - field: "original_task"
+      type: "string"
+      description: "The task as designed for the class"
+    - field: "learner_profile"
+      type: "string"
+      description: "The specific learner need — e.g. extension, support, EAL, ADHD, dyslexia, anxiety, gifted"
+    - field: "learning_objective"
+      type: "string"
+      description: "The learning objective — must remain the same across all differentiated versions"
+  optional:
+    - field: "student_level"
+      type: "string"
+      description: "Age/year group"
+    - field: "subject_area"
+      type: "string"
+      description: "The curriculum subject"
+    - field: "student_profiles"
+      type: "array"
+      description: "From context engine: specific diagnoses, support plans, prior attainment"
+    - field: "available_support"
+      type: "string"
+      description: "TA availability, technology, specialist resources"
+output_schema:
+  type: "object"
+  fields:
+    - field: "adapted_task"
+      type: "object"
+      description: "The differentiated version with specific modifications"
+    - field: "what_changed"
+      type: "string"
+      description: "Explicit statement of what was modified and what was maintained"
+    - field: "objective_check"
+      type: "string"
+      description: "Verification that the learning objective is maintained"
+    - field: "implementation_notes"
+      type: "string"
+      description: "Practical notes for the teacher on implementing the adaptation"
+chains_well_with:
+  - "scaffolded-task-modifier"
+  - "cognitive-load-analyser"
+  - "formative-assessment-technique-selector"
+  - "practice-problem-sequence-designer"
+teacher_time: "3 minutes"
+tags: ["differentiation", "UDL", "inclusion", "SEND", "adaptation"]
+---
+
+# Differentiation Adapter
+
+## What This Skill Does
+
+Adapts a task for a specific learner profile — extension, support, EAL, ADHD, dyslexia, anxiety, visual impairment, autism, gifted and talented — while explicitly maintaining the same learning objective. The critical principle is that differentiation modifies the ROUTE to learning, not the DESTINATION. A student with dyslexia attempting the same learning objective as their peers may need different input formats, different response formats, and different scaffolding — but they should be working toward the same understanding. The output includes the adapted task, an explicit statement of what changed and what stayed the same, a verification that the learning objective is maintained, and implementation notes. AI is specifically valuable here because effective differentiation requires knowledge of both the learner profile (what barriers does this profile create?) and the task (which elements of this task create those barriers?) — a two-way analysis that must be done for each combination of task and learner need.
+
+## Evidence Foundation
+
+Tomlinson (2001, 2014) established the framework for differentiated instruction, identifying three dimensions of differentiation: content (what students learn), process (how they learn it), and product (how they demonstrate learning). She emphasised that differentiation should be by readiness, interest, and learning profile — NOT by learning style (which is excluded from this library as debunked). Rose & Meyer (2002) developed Universal Design for Learning (UDL), arguing that curricula should be designed from the outset to be accessible to all learners through three principles: multiple means of engagement (the "why" of learning), multiple means of representation (the "what"), and multiple means of action and expression (the "how"). Vygotsky (1978) established that instruction should target the Zone of Proximal Development — what the learner can do with appropriate support but not yet independently. Hattie (2009) found that differentiation has moderate effect sizes overall but varies significantly by implementation quality — poorly implemented differentiation (giving weaker students easier work) can actually reduce achievement by lowering expectations. CAST (2018) provided the most current UDL guidelines with specific implementation strategies.
+
+## Input Schema
+
+The teacher must provide:
+- **Original task:** The task as designed. *e.g. "Read the extract from 'A Christmas Carol' and write a paragraph analysing how Dickens presents Scrooge's transformation, using quotations as evidence."*
+- **Learner profile:** The specific need. *e.g. "Extension — student who finishes quickly and needs deeper challenge" / "Support — student with dyslexia who struggles with reading-heavy tasks" / "ADHD — student who struggles with sustained focus on extended writing"*
+- **Learning objective:** What all students should learn. *e.g. "Analyse how Dickens presents character change using textual evidence."*
+
+Optional (injected by context engine if available):
+- **Student level:** Year group
+- **Subject area:** The curriculum subject
+- **Student profiles:** Specific diagnoses, support plans, prior attainment
+- **Available support:** TA, technology, specialist resources
+
+## Prompt
+
+```
+You are an expert in differentiated instruction and inclusive education, with deep knowledge of Tomlinson's (2001, 2014) differentiation framework, Rose & Meyer's (2002) Universal Design for Learning principles, and CAST's (2018) UDL guidelines. You understand that effective differentiation modifies the ROUTE to learning, not the DESTINATION — all students work toward the same learning objective, but the pathway is adapted to remove barriers specific to each learner's profile.
+
+IMPORTANT: Differentiation by learning style (visual/auditory/kinaesthetic preferences) is NOT supported — this is excluded from this library as debunked (Pashler et al., 2008). Differentiation by readiness, specific learning needs, and learner profile IS supported.
+
+Your task is to adapt:
+
+**Original task:** {{original_task}}
+**Learner profile:** {{learner_profile}}
+**Learning objective:** {{learning_objective}}
+
+The following optional context may or may not be provided. Use whatever is available; ignore any fields marked "not provided."
+
+**Student level:** {{student_level}} — if not provided, infer from the task.
+**Subject area:** {{subject_area}} — if not provided, infer from the task.
+**Student profiles:** {{student_profiles}} — if not provided, base adaptations on general research about the stated learner profile.
+**Available support:** {{available_support}} — if not provided, assume standard classroom resources with no specialist TA.
+
+Apply these evidence-based principles:
+
+1. **Same objective, different route (Tomlinson, 2001):**
+   - The learning objective must be identical for the adapted and original task.
+   - Modify HOW the student engages with the content or demonstrates their learning, not WHAT they learn.
+   - If the adaptation reduces cognitive demand, it has gone too far — it should reduce barriers, not reduce thinking.
+
+2. **Profile-specific adaptations (UDL, CAST 2018):**
+   Adapt based on what the research says about each learner profile:
+   - **Extension/Gifted:** Increase depth and complexity — not more of the same, but qualitatively different challenge. Abstract thinking, multiple perspectives, evaluation, creation.
+   - **Support/Below expected level:** Additional scaffolding — sentence frames, graphic organisers, reduced volume (not reduced difficulty), worked examples to reference.
+   - **Dyslexia:** Reduce reading load without reducing thinking. Larger font, coloured overlay, audio version of text, key quotations pre-selected, scribe option for writing. Focus on demonstrating UNDERSTANDING, not reading fluency.
+   - **ADHD:** Break task into shorter chunks with check-in points. Reduce unnecessary information. Provide movement breaks. Use timers for focused bursts. Minimise distractions in the task presentation.
+   - **EAL:** Language scaffolds (sentence frames, word banks, glossary, bilingual support) — see the EAL domain skills for detailed approaches.
+   - **Anxiety:** Reduce performance pressure. Allow draft attempts. Provide clear structure. Offer choice of response format. Avoid cold-calling or public demonstration of work-in-progress.
+   - **Autism:** Provide explicit, unambiguous instructions. Avoid figurative language in task instructions (or gloss it). Provide predictable structure. Allow additional processing time.
+   - **Visual impairment:** Enlarged text, high contrast, audio alternatives, tactile resources where appropriate.
+
+3. **UDL multiple means (Rose & Meyer, 2002):**
+   - **Multiple means of representation:** Can the content be presented differently? (Audio, visual, simplified text alongside original, graphic organiser)
+   - **Multiple means of action and expression:** Can the student demonstrate learning differently? (Verbal instead of written, diagram instead of essay, recorded instead of live)
+   - **Multiple means of engagement:** Can the task be connected to the student's interests or motivations?
+
+4. **Avoid common differentiation errors (Hattie, 2009):**
+   - Do NOT give a simpler version of the task to struggling students — this lowers expectations and reduces learning.
+   - Do NOT give "more work" to extension students — depth, not volume.
+   - Do NOT assume that the adapted version is inherently "lower" — it should be equally demanding but differently accessible.
+
+Return your output in this exact format:
+
+## Adapted Task: [Learner Profile]
+
+**Original task:** [Brief description]
+**Adapted for:** [Learner profile]
+**Learning objective:** [Must be identical to original]
+
+### The Adapted Task
+
+[Complete adapted version of the task with all modifications in place]
+
+### What Changed and What Stayed the Same
+
+**Changed:** [Specific modifications — what was adapted and why]
+**Maintained:** [What was deliberately kept the same — especially cognitive demand and learning objective]
+
+### Objective Check
+
+[Explicit verification: "The adapted task still requires the student to [learning objective] because..."]
+
+### Implementation Notes
+
+[Practical advice for the teacher: how to introduce the adaptation, how to avoid singling the student out, what to watch for]
+
+**Self-check before returning output:** Verify that (a) the learning objective is identical, (b) adaptations address the specific barriers of the stated learner profile, (c) cognitive demand is maintained — the adapted task is not easier, just more accessible, (d) the adaptation is based on research about the learner profile, not on learning style preferences, and (e) the implementation notes address how to manage the adaptation in a classroom without stigmatising the student.
+```
+
+## Example Output
+
+**Scenario:** *Original task: "Read the extract from 'A Christmas Carol' and write a paragraph analysing how Dickens presents Scrooge's transformation, using quotations as evidence." / Learner profile: "Dyslexia — student has a reading age approximately 2 years below chronological age, struggles with decoding longer texts, avoids reading tasks, but demonstrates strong verbal analytical skills in class discussion" / Learning objective: "Analyse how Dickens presents character change using textual evidence" / Student level: "Year 9" / Subject area: "English Literature"*
+
+---
+
+## Adapted Task: Dyslexia
+
+**Original task:** Read the extract from 'A Christmas Carol' and write a paragraph analysing how Dickens presents Scrooge's transformation, using quotations as evidence.
+**Adapted for:** Dyslexia — strong verbal analysis, reading age ~2 years below chronological age
+**Learning objective:** Analyse how Dickens presents character change using textual evidence
+
+### The Adapted Task
+
+**Reading the extract:**
+- Provide the extract printed on cream/buff paper (reduces visual contrast stress) in a minimum 14pt font with 1.5 line spacing.
+- Pre-highlight 4 key quotations that show Scrooge's transformation — these are the quotations the student should focus on. This removes the barrier of scanning dense text to find evidence (a reading-fluency task) while maintaining the requirement to ANALYSE the evidence (the actual learning objective).
+- If audio is available, provide an audio recording of the extract that the student can listen to while following the text. This supports decoding without removing the text entirely.
+
+**Analysing and writing:**
+- Provide a PEEL paragraph frame:
+  - **Point:** "Dickens presents Scrooge's transformation by..."
+  - **Evidence:** "This is shown when Dickens writes '___' (one of the highlighted quotations)"
+  - **Explain:** "This quotation suggests that Scrooge has changed because..."
+  - **Link:** "This shows the reader that..."
+- The student must supply their own analytical thinking at each stage — the frame structures the writing, not the analysis.
+- **Alternative response option:** If writing is the primary barrier (not analysis), offer the student the choice to record their paragraph verbally (voice recording or dictation to a scribe) instead of writing it. The analytical demand is identical; only the output format changes.
+
+### What Changed and What Stayed the Same
+
+**Changed:**
+- Text presentation: larger font, cream paper, increased spacing — reduces decoding load
+- Quotations pre-highlighted: removes the need to scan the full text for evidence — a reading-fluency task, not an analytical task
+- Audio support: optional listening alongside reading
+- Writing scaffold: PEEL frame provided to structure the paragraph
+- Alternative output: verbal response option available
+
+**Maintained:**
+- The learning objective: analyse how Dickens presents character change using textual evidence
+- The requirement to use specific quotations as evidence
+- The analytical demand: the student must explain WHAT the quotation shows and WHY it's significant
+- The quality expectation: the analysis should be just as perceptive as any other student's
+- The text itself: the same extract, not a simplified version
+
+### Objective Check
+
+The adapted task still requires the student to **analyse how Dickens presents character change using textual evidence** because:
+- The student must still READ the extract (with support, but the same text)
+- The student must still SELECT a quotation and explain its significance
+- The student must still ANALYSE — explain what the quotation reveals about Scrooge's transformation and why Dickens chose to present it this way
+- The pre-highlighting removes a reading-fluency barrier, not an analytical barrier — the student still chooses which highlighted quotation to use and must explain its significance independently
+- The PEEL frame structures the writing but does not supply the analytical content — every "Explain" and "Link" section requires the student's own thinking
+
+### Implementation Notes
+
+1. **Introduce the adaptation discreetly.** Don't announce "This is the dyslexia version." Instead, make some adaptations available to all students: print the extract on cream paper for everyone (it helps all readers). Make the audio version available to the whole class. Differentiate the highlighted quotations individually — hand them out rather than projecting.
+
+2. **Monitor the analysis, not the writing.** This student's strength is verbal analysis. If the written response is weaker than expected, check whether the barrier is writing-mechanics (spelling, handwriting, sentence construction) or analysis. If the student can explain their analysis verbally but not in writing, the barrier is writing production, not understanding — and the voice-recording option should be offered.
+
+3. **Don't lower expectations for analytical quality.** The student with dyslexia has strong verbal analytical skills. Their analysis should be held to the same standard as any other student's. The adaptation removes a barrier; it does not lower the bar. If the student's written paragraph is thin, the response is "Can you tell me more about what this quotation shows?" — pushing for depth — not "Well done for trying."
+
+4. **Revisit the pre-highlighting over time.** Pre-selecting quotations is a scaffold that should be reduced as the student develops reading stamina and confidence. Next time, highlight 6 quotations and ask the student to choose the best 2. Eventually, provide the text without highlighting and see if the student can identify evidence independently (perhaps with more time).
+
+---
+
+## Known Limitations
+
+1. **The adaptation is based on general research about the learner profile, not on the individual student.** Dyslexia manifests differently in different students — some struggle primarily with decoding, others with reading speed, others with working memory. The teacher's knowledge of the specific student is essential for refining the adaptation. If the student's dyslexia primarily affects spelling rather than reading, the adaptations should be different.
+
+2. **Differentiation by learning style is explicitly excluded.** This skill does not adapt tasks based on "visual," "auditory," or "kinaesthetic" preferences — the evidence does not support this approach (Pashler et al., 2008). Adaptations are based on researched barriers associated with specific learning needs, not on preferences.
+
+3. **Adapted tasks can inadvertently signal low expectations.** If a student consistently receives "different" work, they may internalise the message that they are less capable. The implementation notes address this, but the teacher must be vigilant about framing adaptations as access support (like glasses for someone who needs them), not as reduced expectations. The goal is equity — the same learning, differently accessed — not a lower track.

--- a/skill-library/explicit-instruction-sequence-builder/SKILL.md
+++ b/skill-library/explicit-instruction-sequence-builder/SKILL.md
@@ -1,0 +1,288 @@
+---
+# AGENT SKILLS STANDARD FIELDS (v2)
+name: explicit-instruction-sequence-builder
+category: 教学辅导
+description: >-
+  构建完整的显性教学课时序列:教师示范(I Do)→ 引导练习(We Do)→ 独立练习(You Do),含各阶段理解检查点、时间分配、示例与常见误区,基于渐进释放责任模型。教新技能/新步骤/新概念、需要一份能直接上课的课时教案时使用。触发词:一节课教案, 课时设计, 讲课流程, 教学过程设计, 示范讲解, 精讲精练, 显性教学, 我讲你练; explicit instruction, lesson sequence, gradual release, I do we do you do.
+disable-model-invocation: false
+user-invocable: true
+effort: medium
+
+# EXISTING FIELDS
+
+skill_id: "explicit-instruction/explicit-instruction-sequence-builder"
+skill_name: "Explicit Instruction Sequence Builder (I Do / We Do / You Do)"
+domain: "explicit-instruction"
+version: "1.0"
+evidence_strength: "strong"
+evidence_sources:
+  - "Rosenshine (2012) — Principles of Instruction: research-based strategies that all teachers should know"
+  - "Pearson & Gallagher (1983) — The instruction of reading comprehension (gradual release of responsibility model)"
+  - "Archer & Hughes (2011) — Explicit Instruction: Effective and Efficient Teaching"
+  - "Hattie (2009) — Visible Learning: direct instruction effect size 0.59"
+  - "Engelmann & Carnine (1982) — Theory of Instruction: principles and applications"
+input_schema:
+  required:
+    - field: "skill_to_teach"
+      type: "string"
+      description: "The specific skill or concept to be taught through explicit instruction"
+    - field: "student_level"
+      type: "string"
+      description: "Age/year group and prior knowledge level"
+    - field: "lesson_time"
+      type: "string"
+      description: "Available lesson time in minutes"
+  optional:
+    - field: "common_misconceptions"
+      type: "array"
+      description: "Known misconceptions or errors students make with this skill"
+    - field: "student_profiles"
+      type: "array"
+      description: "From context engine: ability range, EAL needs, SEND profiles"
+    - field: "prior_knowledge"
+      type: "string"
+      description: "What students already know that this builds on"
+    - field: "success_criteria"
+      type: "string"
+      description: "From context engine: how success will be measured"
+output_schema:
+  type: "object"
+  fields:
+    - field: "i_do"
+      type: "object"
+      description: "Teacher modelling phase with scripted explanation and think-aloud"
+    - field: "we_do"
+      type: "object"
+      description: "Guided practice phase with structured teacher-student interaction"
+    - field: "you_do"
+      type: "object"
+      description: "Independent practice phase with monitoring checkpoints"
+    - field: "cfu_points"
+      type: "array"
+      description: "Checking for understanding moments embedded throughout"
+    - field: "timing_guide"
+      type: "string"
+      description: "Suggested time allocation across the three phases"
+chains_well_with:
+  - "checking-for-understanding-protocol-designer"
+  - "worked-example-fading-designer"
+  - "think-aloud-script-generator"
+  - "practice-problem-sequence-designer"
+  - "pedagogical-content-knowledge-developer"
+teacher_time: "5 minutes"
+tags: ["explicit-instruction", "gradual-release", "modelling", "direct-instruction", "scaffolding"]
+---
+
+# Explicit Instruction Sequence Builder (I Do / We Do / You Do)
+
+## What This Skill Does
+
+Generates a complete gradual release of responsibility sequence for teaching a specific skill: a scripted "I Do" (teacher models with think-aloud), a structured "We Do" (guided practice with teacher-student interaction), and a designed "You Do" (independent practice with monitoring points). The output includes checking-for-understanding moments at each transition and a timing guide. AI is specifically valuable here because effective explicit instruction requires the teacher to make invisible expert thinking visible — breaking down a skill they perform automatically into discrete, teachable steps with articulated reasoning. This decomposition of expert performance is cognitively demanding and is where most explicit instruction falls short.
+
+## Evidence Foundation
+
+Rosenshine (2012) synthesised decades of research into ten Principles of Instruction, with explicit instruction at the core: begin with a short review, present new material in small steps with practice after each step, provide models, guide student practice, check for understanding, and obtain a high success rate. Pearson & Gallagher (1983) formalised the gradual release of responsibility model — the teacher begins by carrying all cognitive load (I Do), progressively shares it with students (We Do), then transfers it entirely (You Do). Archer & Hughes (2011) operationalised explicit instruction for practitioners, emphasising that the "I Do" phase must include not just demonstration but articulation of the decision-making process — students need to hear *why* each step is taken, not just see it done. Hattie (2009) found direct instruction has an effect size of 0.59, consistently among the highest-impact teaching approaches. Engelmann & Carnine (1982) established that the sequence and structure of examples in explicit instruction dramatically affects learning — examples must be carefully selected to highlight critical features and minimise ambiguity.
+
+## Input Schema
+
+The teacher must provide:
+- **Skill to teach:** The specific skill or concept. *e.g. "Writing a topic sentence for an analytical paragraph" / "Converting between fractions, decimals, and percentages" / "Setting up a Bunsen burner safely"*
+- **Student level:** Year group and prior knowledge. *e.g. "Year 8, can write paragraphs but don't structure analytical writing" / "Year 7, first time using lab equipment"*
+- **Lesson time:** Available minutes. *e.g. "50 minutes" / "60 minutes"*
+
+Optional (injected by context engine if available):
+- **Common misconceptions:** Known errors with this skill
+- **Student profiles:** Ability range, EAL needs, SEND profiles
+- **Prior knowledge:** What students already know
+- **Success criteria:** How success will be measured
+
+## Prompt
+
+```
+You are an expert in explicit instruction and the gradual release of responsibility model, with deep knowledge of Rosenshine's (2012) Principles of Instruction, Pearson & Gallagher's (1983) gradual release framework, and Archer & Hughes' (2011) work on effective modelling. You understand that the critical quality of explicit instruction is making expert thinking visible — not just showing students what to do, but articulating the decision-making process behind each step.
+
+Your task is to design a complete I Do / We Do / You Do sequence for:
+
+**Skill:** {{skill_to_teach}}
+**Student level:** {{student_level}}
+**Lesson time:** {{lesson_time}}
+
+The following optional context may or may not be provided. Use whatever is available; ignore any fields marked "not provided."
+
+**Common misconceptions:** {{common_misconceptions}} — if not provided, identify the most likely misconceptions for this skill based on your subject knowledge and address them in the modelling phase.
+**Student profiles:** {{student_profiles}} — if not provided, design for a typical mixed-ability class and note where differentiation would be needed.
+**Prior knowledge:** {{prior_knowledge}} — if not provided, state the assumed prerequisite knowledge explicitly so the teacher can verify.
+**Success criteria:** {{success_criteria}} — if not provided, generate clear success criteria that describe what successful performance looks like at the end of the lesson.
+
+Apply these evidence-based principles:
+
+1. **I Do — Teacher models with think-aloud (Rosenshine, 2012; Archer & Hughes, 2011):**
+   - Demonstrate the complete skill from start to finish.
+   - Articulate your thinking at EVERY decision point — not just what you're doing, but WHY. "I'm choosing this word because..." / "At this point I need to decide between X and Y, and I choose X because..."
+   - Highlight critical features: what makes this different from similar tasks.
+   - Show common errors and explain why they're wrong (inoculation against misconceptions).
+   - Keep it concise — modelling should be 10–15 minutes maximum. Students learn by doing, not by watching.
+
+2. **We Do — Guided practice with high interaction (Rosenshine, 2012, Principle 4):**
+   - Teacher and students work through a new example TOGETHER.
+   - Teacher does the early steps, students take over progressively.
+   - Use frequent checking: "What should I do next?" / "Why did I choose that?" / cold-calling for responses.
+   - This is NOT the teacher doing another example while students watch. Students must be actively contributing.
+   - Aim for 80%+ success rate before moving to You Do (Rosenshine, 2012, Principle 7).
+
+3. **You Do — Independent practice with monitoring (Rosenshine, 2012, Principles 5 & 8):**
+   - Students practise independently. The teacher circulates and monitors.
+   - Begin with problems very similar to the modelled example, then gradually vary.
+   - Include a monitoring plan: what to look for, when to intervene, how to identify students who need re-teaching.
+   - Build in a checkpoint: after 5 minutes of independent work, quick whole-class check before students continue.
+
+4. **Checking for Understanding at each transition (Rosenshine, 2012, Principle 3):**
+   - Between I Do and We Do: "Before we try one together, tell your partner: what is the first step?"
+   - Between We Do and You Do: "Give me a thumbs up if you could do the next one on your own, sideways if you need one more guided example, down if you're not sure."
+   - During You Do: circulate and check 5 specific students' work within the first 3 minutes.
+
+5. **Time allocation (Archer & Hughes, 2011):**
+   - I Do: ~20% of lesson time
+   - We Do: ~30% of lesson time
+   - You Do: ~40% of lesson time
+   - Transitions and CFU: ~10%
+   - If time is short, compress I Do (not We Do or You Do — students need practice time).
+
+Return your output in this exact format:
+
+## Explicit Instruction Sequence: [Skill Name]
+
+**For:** [Student level]
+**Time:** [Lesson time]
+**Success criteria:** [What students will be able to do by the end]
+
+### Prerequisites
+[What students need to know before this lesson — teacher should verify]
+
+### I Do — Teacher Models (approx. X minutes)
+
+**Setup:** [How to frame the skill and connect to prior knowledge]
+**Model:** [Step-by-step demonstration with think-aloud script at each decision point]
+**Common error inoculation:** [Show a common mistake and explain why it's wrong]
+
+**CFU checkpoint:** [Quick check before moving to We Do]
+
+### We Do — Guided Practice (approx. X minutes)
+
+**Example:** [A new example for guided practice]
+**Interaction plan:** [Which steps the teacher does, which students contribute, how to elicit responses]
+**Scaffolding notes:** [Support for students who are struggling / extension for those who are ready]
+
+**CFU checkpoint:** [Check readiness for independent practice]
+
+### You Do — Independent Practice (approx. X minutes)
+
+**Practice set:** [4–6 practice problems/tasks, sequenced from similar-to-model to varied]
+**Monitoring plan:** [What to look for, which students to check first, intervention triggers]
+**Early finisher extension:** [What to do with students who finish quickly]
+
+### Differentiation Notes
+[How to adjust for different ability levels without changing the learning intention]
+
+**Self-check before returning output:** Verify that (a) the I Do phase includes think-aloud reasoning at every decision point, not just demonstration, (b) the We Do phase requires active student contribution, not passive watching, (c) the You Do practice problems progress from similar-to-model to varied, (d) CFU checkpoints are embedded at each transition, (e) timing is realistic for the stated lesson length, and (f) common misconceptions are addressed during modelling, not left for students to discover.
+```
+
+## Example Output
+
+**Scenario:** *Skill: "Writing a topic sentence for an analytical paragraph in English Literature" / Student level: "Year 9, can write paragraphs but topic sentences are typically descriptive rather than analytical" / Lesson time: "50 minutes"*
+
+---
+
+## Explicit Instruction Sequence: Writing Analytical Topic Sentences
+
+**For:** Year 9 English Literature
+**Time:** 50 minutes
+**Success criteria:** Students can write a topic sentence that makes an analytical claim about a writer's method or intention — not a descriptive statement about what happens in the text.
+
+### Prerequisites
+Students should be able to: write a complete sentence, identify a quotation from a text, and understand the difference between a character's action and a writer's choice. Teacher should verify with a quick question: "What's the difference between saying 'Macbeth kills Duncan' and 'Shakespeare presents Macbeth as increasingly corrupted by ambition'?"
+
+### I Do — Teacher Models (10 minutes)
+
+**Setup (2 minutes):**
+"Today I'm going to teach you how to write the first sentence of an analytical paragraph — the topic sentence. This is the sentence that tells the reader what your paragraph will argue. The key word is *argue*. Your topic sentence is a claim, not a description. Watch what I do, and listen to my thinking."
+
+**Model (6 minutes):**
+
+"I'm writing about how Shakespeare presents Lady Macbeth's ambition in Act 1. Let me write a topic sentence.
+
+My first instinct is: 'In Act 1, Lady Macbeth is very ambitious.' Let me check — is this a claim or a description? It's a description. It tells you what Lady Macbeth is like, but it doesn't say anything about what Shakespeare is DOING. I need to shift from character to writer.
+
+Let me try again: 'Shakespeare presents Lady Macbeth's ambition as more ruthless and calculated than Macbeth's own, using her soliloquy in Act 1, Scene 5 to reveal a character who consciously chooses to suppress her humanity.'
+
+Now let me check this against my criteria:
+- Does it name the writer? Yes — 'Shakespeare presents.'
+- Does it make a claim that could be argued? Yes — someone could disagree that her ambition is 'more ruthless' or that she 'consciously chooses.'
+- Does it point to a method? Yes — 'using her soliloquy' tells the reader I'll be analysing specific language.
+- Could I write a whole paragraph developing this idea? Yes — I'd analyse the 'unsex me here' speech.
+
+That's a strong topic sentence. Now let me show you a common mistake."
+
+**Common error inoculation (2 minutes):**
+"Here's what most Year 9 students write: 'In Act 1, Lady Macbeth reads a letter and then asks the spirits to unsex her.'
+
+This is a description of what happens. It's accurate. It's also useless as a topic sentence because there's nothing to argue — it's just a plot summary. Notice the difference:
+- Description: 'Lady Macbeth asks the spirits to unsex her.' (What happens)
+- Analysis: 'Shakespeare uses Lady Macbeth's invocation of dark spirits to suggest that ambition in this play requires the destruction of feminine compassion.' (What the writer is doing and why)
+
+The shift is from CHARACTER to WRITER. From WHAT HAPPENS to WHY THE WRITER MADE IT HAPPEN."
+
+**CFU checkpoint:**
+"Turn to your partner. Tell them: what is the difference between a descriptive topic sentence and an analytical one? You have 30 seconds." Cold-call 2 students to share. Listen for: references to the writer's choices/methods vs. character actions/plot.
+
+### We Do — Guided Practice (15 minutes)
+
+**Example:** "Now let's write one together. The question is: How does Shakespeare present the theme of violence in Act 3, Scene 1?"
+
+**Interaction plan:**
+
+*Step 1 — Teacher leads:* "What's the first thing I need in my topic sentence? I need to name the writer. So I'm starting with 'Shakespeare...' What verb comes next? Not 'writes about' — that's too vague. Give me a stronger verb." Elicit from class: presents / conveys / demonstrates / reveals / constructs. "Good — 'Shakespeare presents...' What does he present?"
+
+*Step 2 — Students contribute with support:* "Now I need a claim about violence in Act 3, Scene 1. Don't describe what happens — make an argument about what Shakespeare is DOING with violence. Write a claim on your whiteboard." Students write. Teacher scans boards. Select a strong example and a weak example (anonymised). "This one says 'violence as an inevitable consequence of unchecked masculinity.' That's a claim — someone could argue the opposite. This one says 'Tybalt and Romeo fight and Mercutio dies.' That's a description. Let's upgrade it together — what is Shakespeare saying about violence through this scene?"
+
+*Step 3 — Students lead:* "Now add a reference to method. How does Shakespeare present this? What technique or structural choice? Write the complete topic sentence." Students write. Teacher circulates and reads 6–8 boards. Class shares and evaluates: does it name the writer, make a claim, and point to method?
+
+**Scaffolding notes:**
+- Students struggling: provide a sentence frame: "Shakespeare presents [theme] as [claim] through [method], suggesting that [interpretation]."
+- Students ready for challenge: can they write a topic sentence that acknowledges a counterargument? "While Shakespeare initially presents violence as... , Act 3, Scene 1 reveals..."
+
+**CFU checkpoint:**
+"Thumbs up if you could write the next topic sentence on your own. Sideways if you'd like one more example together. Down if you're stuck." If more than 30% sideways or down, do one more guided example. If 80%+ up, move to You Do.
+
+### You Do — Independent Practice (20 minutes)
+
+**Practice set:**
+
+1. Write a topic sentence for: "How does Shakespeare present Mercutio as a contrast to Romeo?" *(Very close to the modelled example — same text, same skill)*
+2. Write a topic sentence for: "How does Steinbeck present loneliness in the opening of Of Mice and Men?" *(Same skill, different text — tests transfer)*
+3. Write a topic sentence for: "How does the poet present the experience of conflict in 'Bayonet Charge'?" *(Same skill, poetry context — further transfer)*
+4. **Challenge:** Write two alternative topic sentences for the same question. Which is stronger? Annotate why.
+
+**Monitoring plan:**
+- First 3 minutes: check the 5 students you're most concerned about (those who were sideways/down at the CFU). Read their first sentence. If it's descriptive rather than analytical, intervene immediately with the sentence frame scaffold.
+- Minute 5: whole-class pause. "Read your first topic sentence to your partner. Partner, tell them: does it name the writer, make a claim, and point to method? If it doesn't, fix it now."
+- Minutes 5–20: circulate systematically. Look for the common error (description instead of analysis). Collect 2–3 strong examples and 1 weak example for whole-class feedback in the last 5 minutes.
+
+**Early finisher extension:**
+Write a topic sentence for a subject of your choice (History, Science, Geography) that uses the same analytical structure: names the creator/author/cause, makes a claim, and points to a method or mechanism. This tests whether students have understood the transferable skill, not just the English Literature application.
+
+### Differentiation Notes
+
+- **Support:** The sentence frame ("Shakespeare presents [theme] as [claim] through [method]") remains available throughout You Do for students who need it. This is scaffolding, not reducing the task — they're still making an analytical claim, just with structural support.
+- **EAL students:** Pre-teach the analytical verbs (presents, conveys, reveals, constructs, demonstrates) with definitions before the lesson or provide a word bank during the task.
+- **Extension:** Challenge students to write topic sentences that embed a concession or counterargument ("Although... , Shakespeare ultimately presents..."). This adds syntactic complexity while maintaining the same analytical skill.
+
+---
+
+## Known Limitations
+
+1. **Explicit instruction is most effective for skills with identifiable steps and clear success criteria.** Writing an analytical topic sentence can be decomposed into steps. Creative writing, open-ended problem-solving, and tasks with multiple valid approaches are less suited to rigid I Do / We Do / You Do sequences. For open-ended tasks, the modelling phase should show the decision-making process, not a single "correct" approach.
+
+2. **The quality of the I Do phase depends entirely on the teacher's ability to articulate their thinking.** The script provides a model, but the teacher must deliver it in their own voice and adapt to their students' responses. A robotically read script is worse than a slightly less polished but authentic think-aloud. Teachers should rehearse the think-aloud, not read it.
+
+3. **There is a risk of over-scaffolding in the We Do phase.** If the teacher does too much and students contribute too little, the "guided practice" becomes a second demonstration. The interaction plan specifies where students take over, but teachers must resist the urge to jump in when students hesitate — productive struggle during We Do is appropriate as long as the success rate stays above 80%.

--- a/skill-library/formative-assessment-technique-selector/SKILL.md
+++ b/skill-library/formative-assessment-technique-selector/SKILL.md
@@ -1,0 +1,255 @@
+---
+# AGENT SKILLS STANDARD FIELDS (v2)
+name: formative-assessment-technique-selector
+category: 教学辅导
+description: >-
+  为具体的教学时刻、评估目的与学段挑选合适的形成性评估/随堂检测技术(基于 Black & Wiliam 等循证研究):给出 2–3 种按适配度排序的技术、实施步骤、如何解读学生应答以及常见误区。想在课中、课间或课后检查学生是否学会、设计随堂反馈时使用。触发词:随堂检测, 形成性评价, 课堂提问, 检查理解, 当堂反馈, 出口卡, 学情检测, 怎么知道学生学会没有; formative assessment, check for understanding, exit ticket, hinge question.
+disable-model-invocation: true
+user-invocable: true
+effort: medium
+
+# EXISTING FIELDS
+
+skill_id: "curriculum-assessment/formative-assessment-technique-selector"
+skill_name: "Formative Assessment Technique Selector"
+domain: "curriculum-assessment"
+version: "1.0"
+evidence_strength: "strong"
+evidence_sources:
+  - "Black & Wiliam (1998) — Assessment and Classroom Learning"
+  - "Wiliam (2011) — Embedded Formative Assessment"
+  - "Leahy et al. (2005) — Classroom Assessment: minute by minute, day by day"
+  - "Heritage (2010) — Formative Assessment: making it happen in the classroom"
+  - "Wiliam & Leahy (2015) — Embedding Formative Assessment: practical techniques for K–12 classrooms"
+input_schema:
+  required:
+    - field: "learning_moment"
+      type: "string"
+      description: "When in the lesson/sequence the assessment happens — e.g. during teacher explanation, after guided practice, end of lesson, between lessons, start of next lesson"
+    - field: "what_to_assess"
+      type: "string"
+      description: "The specific understanding, skill, or knowledge to check"
+    - field: "student_level"
+      type: "string"
+      description: "Age/year group"
+  optional:
+    - field: "class_size"
+      type: "integer"
+      description: "Number of students — affects technique practicality"
+    - field: "subject_area"
+      type: "string"
+      description: "The curriculum subject"
+    - field: "student_profiles"
+      type: "array"
+      description: "From context engine: EAL students, confidence levels, specific needs"
+    - field: "available_resources"
+      type: "string"
+      description: "Mini-whiteboards, technology, exit ticket slips, etc."
+output_schema:
+  type: "object"
+  fields:
+    - field: "recommended_techniques"
+      type: "array"
+      description: "2–3 techniques ranked by suitability, with implementation guide for each"
+    - field: "technique_rationale"
+      type: "string"
+      description: "Why each technique is appropriate for this specific moment and purpose"
+    - field: "response_interpretation"
+      type: "object"
+      description: "How to interpret responses — what patterns mean and what to do next"
+    - field: "common_mistakes"
+      type: "string"
+      description: "How the technique can go wrong and how to avoid it"
+chains_well_with:
+  - "hinge-question-designer"
+  - "checking-for-understanding-protocol-designer"
+  - "exit-ticket-designer"
+  - "explicit-instruction-sequence-builder"
+  - "kud-knowledge-type-mapper"
+teacher_time: "2 minutes"
+tags: ["formative-assessment", "checking-understanding", "AfL", "feedback", "responsive-teaching"]
+---
+
+# Formative Assessment Technique Selector
+
+## What This Skill Does
+
+Selects the most appropriate formative assessment technique for a specific learning moment — during instruction, after guided practice, at the end of a lesson, or between lessons — and provides a complete implementation guide including how to interpret the responses and what to do next based on what the data shows. Unlike generic lists of formative assessment ideas, this skill matches the technique to the specific moment, purpose, and practical constraints. A technique that works brilliantly at the end of a lesson (exit ticket) is useless during a teacher explanation; a technique that works for checking factual recall (mini-whiteboards) is inappropriate for checking deep understanding (which requires explanation, not single answers). AI is specifically valuable here because selecting the right technique requires matching the assessment purpose (what am I checking?), the timing (when in the lesson?), the response format (do I need quick data from everyone, or deep data from a few?), and the practical constraints (class size, resources, time).
+
+## Evidence Foundation
+
+Black & Wiliam (1998) established formative assessment as one of the highest-leverage interventions in education (effect size 0.4–0.7), but crucially defined it by its function, not its form: assessment is formative only when the evidence is used to adapt teaching. Giving an exit ticket and not reading it until the next day is not formative assessment — it's delayed summative assessment. Wiliam (2011) operationalised formative assessment into five key strategies: clarifying intentions, engineering discussions, providing feedback, activating students as resources for each other, and activating students as owners of their learning. Leahy et al. (2005) translated these strategies into practical classroom techniques, emphasising that formative assessment must be embedded in instruction — not bolted on. Heritage (2010) distinguished between planned formative assessment (designed into the lesson in advance) and interactive formative assessment (responsive, in-the-moment), arguing that both are necessary but serve different purposes. Wiliam & Leahy (2015) provided comprehensive implementation guidance, emphasising that the best techniques collect evidence from ALL students, not just volunteers.
+
+## Input Schema
+
+The teacher must provide:
+- **Learning moment:** When in the sequence. *e.g. "During my explanation of how to add fractions with unlike denominators — I need to check before moving on" / "After students have completed 5 practice problems independently" / "End of the lesson — I need to know who's got it and who hasn't" / "Start of next lesson — checking retention from yesterday"*
+- **What to assess:** The specific thing to check. *e.g. "Can students identify the common denominator?" / "Do students understand why the character made that decision?" / "Can students apply the formula to a new context?"*
+- **Student level:** Year group. *e.g. "Year 7"*
+
+Optional (injected by context engine if available):
+- **Class size:** Number of students
+- **Subject area:** The curriculum subject
+- **Student profiles:** EAL, confidence levels, specific needs
+- **Available resources:** Equipment available
+
+## Prompt
+
+```
+You are an expert in formative assessment and responsive teaching, with deep knowledge of Black & Wiliam's (1998) research on assessment for learning, Wiliam's (2011) five key strategies, Leahy et al.'s (2005) practical techniques, and Heritage's (2010) distinction between planned and interactive formative assessment. You understand that formative assessment is defined by its FUNCTION (using evidence to adapt teaching), not its FORM (any particular technique) — and that the right technique depends on the specific learning moment, the type of understanding being assessed, and the practical constraints.
+
+Your task is to select formative assessment techniques for:
+
+**Learning moment:** {{learning_moment}}
+**What to assess:** {{what_to_assess}}
+**Student level:** {{student_level}}
+
+The following optional context may or may not be provided. Use whatever is available; ignore any fields marked "not provided."
+
+**Class size:** {{class_size}} — if not provided, assume 25–30 students.
+**Subject area:** {{subject_area}} — if not provided, infer from the assessment focus.
+**Student profiles:** {{student_profiles}} — if not provided, assume a mixed-ability class with some EAL students and some reluctant participants.
+**Available resources:** {{available_resources}} — if not provided, assume mini-whiteboards are available but no technology.
+
+Apply these evidence-based principles:
+
+1. **Every student, not just volunteers (Wiliam, 2011):**
+   - The technique must collect evidence from ALL students, not just those who raise their hands.
+   - "Hands up" is NOT formative assessment — it only tells you about the 5–6 students who volunteer. It tells you nothing about the other 20–25.
+   - Techniques that collect data from every student: mini-whiteboards, exit tickets, finger voting, all-student response systems, think-pair-share with reporting.
+
+2. **Match technique to purpose (Heritage, 2010):**
+   - **Checking factual knowledge:** Quick-response techniques — mini-whiteboards, finger voting, true/false cards. Speed matters; depth doesn't.
+   - **Checking understanding:** Explanation-based techniques — think-pair-share, exit tickets with reasoning, hinge questions with diagnostic distractors. Depth matters; speed is secondary.
+   - **Checking application:** Task-based techniques — practice problems with monitoring, worked examples with a gap, mini-tasks. Observation of process matters.
+   - **Checking misconceptions:** Diagnostic techniques — hinge questions with misconception-targeted distractors, deliberate error identification tasks.
+
+3. **Match technique to timing (Leahy et al., 2005):**
+   - **During instruction (real-time):** Must be fast (under 60 seconds), non-disruptive, and provide immediate data. Mini-whiteboards, finger voting, traffic lights.
+   - **After guided practice:** Must reveal whether students can apply independently. Quick practice problem, show-me task, partner explanation.
+   - **End of lesson:** Must capture what students are leaving with. Exit ticket (3–5 minutes), summary task, one-sentence explanation.
+   - **Between lessons:** Must check retention and inform the next lesson. Retrieval quiz at start of next lesson, homework analysis.
+
+4. **Interpret and act (Black & Wiliam, 1998):**
+   - The technique is only formative if the teacher USES the data to adapt teaching.
+   - For each technique, provide: what response patterns mean, and what to DO based on each pattern.
+   - 80%+ correct → proceed. 50–80% → brief re-teach. Below 50% → significant reteach needed.
+
+5. **Avoid pseudo-formative assessment:**
+   - "Thumbs up if you understand" is NOT formative assessment — students cannot accurately self-assess understanding in the moment, and social pressure ensures most thumbs go up.
+   - "Any questions?" is NOT formative assessment — students who don't understand often don't know what to ask.
+   - The technique must require students to DEMONSTRATE understanding, not just claim it.
+
+Return your output in this exact format:
+
+## Formative Assessment: [What's being assessed]
+
+**Moment:** [When in the lesson]
+**Assessing:** [Specific understanding/skill]
+**For:** [Student level]
+
+### Recommended Techniques
+
+For each technique (2–3, ranked):
+
+**Technique [N]: [Name]**
+**How it works:** [Step-by-step implementation]
+**Time required:** [Minutes]
+**Why this technique for this moment:** [Specific rationale]
+**What to look for:** [Specific responses that indicate understanding vs. confusion]
+
+### Response Interpretation Guide
+
+**If 80%+ demonstrate understanding:** [What to do]
+**If 50–80% demonstrate understanding:** [What to do]
+**If below 50%:** [What to do]
+**If you see [specific common error]:** [What it means and what to do]
+
+### Common Mistakes with These Techniques
+
+[2–3 ways the technique can fail and how to prevent it]
+
+**Self-check before returning output:** Verify that (a) the recommended technique collects data from ALL students, (b) the technique is matched to the specific learning moment and purpose, (c) the implementation guide is specific enough for a teacher to use immediately, (d) the response interpretation includes specific actions, and (e) no recommended technique relies on volunteers or self-report.
+```
+
+## Example Output
+
+**Scenario:** *Learning moment: "I've just finished explaining how to calculate the area of a triangle (base × height ÷ 2). I've shown two worked examples. Before I set practice problems, I need to check whether students understand the method well enough to try independently." / What to assess: "Can students correctly calculate the area of a triangle when given the base and height?" / Student level: "Year 7" / Subject area: "Mathematics" / Available resources: "Mini-whiteboards available"*
+
+---
+
+## Formative Assessment: Area of a Triangle Calculation
+
+**Moment:** After teacher explanation and worked examples, before independent practice
+**Assessing:** Can students correctly calculate the area of a triangle when given base and height?
+**For:** Year 7 Mathematics
+
+### Recommended Techniques
+
+**Technique 1: Mini-Whiteboard Show-Me (Recommended)**
+**How it works:**
+1. Display a triangle with base = 8cm, height = 5cm on the board.
+2. Say: "Calculate the area of this triangle. Show your working on your whiteboard. You have 60 seconds."
+3. After 60 seconds: "3, 2, 1, show me." All students hold up whiteboards simultaneously.
+4. Scan the room. Look for the correct answer (20cm²) and the working.
+5. If time allows, repeat with a second triangle (different numbers) to confirm.
+
+**Time required:** 2–3 minutes (including the follow-up problem)
+**Why this technique for this moment:** This is a procedural check — can students apply a formula correctly? Mini-whiteboards are ideal because they collect data from every student simultaneously, they show WORKING (not just answers), and they provide instant feedback. The "3, 2, 1, show me" protocol prevents students from copying — everyone reveals at the same time.
+**What to look for:**
+- Correct answer with correct working (20cm²: 8 × 5 = 40, 40 ÷ 2 = 20) → student is ready for practice
+- Answer of 40cm² → student multiplied but forgot to divide by 2
+- Answer of 13cm² → student added instead of multiplied (8 + 5 = 13)
+- Blank whiteboard or random number → student doesn't know where to start — didn't understand the worked examples
+
+**Technique 2: Finger Voting on a Hinge Question**
+**How it works:**
+1. Display: "A triangle has a base of 6cm and a height of 4cm. What is the area?"
+   A) 10cm²    B) 12cm²    C) 24cm²    D) 20cm²
+2. Say: "Think about this. Do NOT call out. When I say go, hold up fingers: 1 for A, 2 for B, 3 for C, 4 for D."
+3. "3, 2, 1, show me." Scan the room.
+
+**Time required:** 1–2 minutes
+**Why this technique for this moment:** Faster than whiteboards. The distractors are diagnostic: A (10) = added instead of multiplied; B (12) = correct; C (24) = multiplied but didn't divide by 2; D (20) = common plausible wrong answer. Each wrong answer reveals a specific error.
+**What to look for:**
+- Fingers showing 2 (B, correct: 12cm²) → student understands the method
+- Fingers showing 3 (C, 24cm²) → student multiplied correctly but didn't halve — most common error
+- Fingers showing 1 (A, 10cm²) → student added base and height instead of multiplying
+
+**Technique 3: Partner Explain (for checking deeper understanding)**
+**How it works:**
+1. "Turn to your partner. Person A: explain to Person B how to calculate the area of a triangle. Don't just say the answer — explain the METHOD. Person B: listen and check — are they correct?"
+2. After 60 seconds: "Person B — put your hand up if Person A explained it correctly."
+3. Cold-call 2–3 Person B students: "What did your partner say?"
+
+**Time required:** 3–4 minutes
+**Why this technique for this moment:** Use this if you want to check whether students can EXPLAIN the method, not just apply it. Explaining to a peer reveals deeper understanding than calculating an answer. However, it's slower and provides less precise data than whiteboards.
+**What to look for:** Can students articulate "multiply the base by the height, then divide by 2" — or do they say "I just did 8 times 5 divided by 2" without understanding why? Listen for whether they can explain the ÷ 2 step: "because a triangle is half of a rectangle."
+
+### Response Interpretation Guide
+
+**If 80%+ get the correct answer (Technique 1 or 2):** Proceed to independent practice. Students are ready. Set 6–8 problems with increasing difficulty (including triangles where the height is not a vertical line from the base — this is the next common difficulty).
+
+**If 50–80% get the correct answer:** Identify the most common error. If most errors are "forgot to ÷ 2" (answer of 40 or 24): brief 2-minute re-teach. "I can see many of you multiplied correctly but forgot one step. Look — a triangle is HALF of a rectangle. So the area is HALF of base times height. Watch me do one more." Re-do one example emphasising the ÷ 2, then re-check with whiteboards.
+
+**If below 50% get the correct answer:** Do NOT proceed to practice — students will practise the wrong method and embed errors. Return to the explanation. "I can see many of you are unsure. That's fine — this is tricky. Let me show you again from the start." Re-teach using a different representation (e.g., cut a rectangle in half diagonally to show that the triangle is half the rectangle). Then re-check.
+
+**If you see "added instead of multiplied" (answer of 13 or 10):** This student has confused the area formula with the perimeter concept. They need clarification: "Area is the space INSIDE the shape — we multiply to find how many square centimetres fit inside. Perimeter is the distance AROUND the outside — that's when we add."
+
+### Common Mistakes with These Techniques
+
+1. **Allowing students to show whiteboards at different times.** If students reveal answers one by one, later students copy earlier ones. The "3, 2, 1, show me" simultaneous reveal is essential — it prevents copying and gives you an honest snapshot of the whole class.
+
+2. **Only looking at the answer, not the working.** A student who writes "20cm²" has the right answer, but did they calculate 8 × 5 ÷ 2, or did they guess? Looking at the working distinguishes genuine understanding from lucky guesses. On whiteboards, require working to be shown.
+
+3. **Asking "Does everyone understand?" after the check.** If the whiteboard data shows 85% correct, proceed. Don't undermine the data by then asking a question that will always get "yes." Trust the evidence over self-report.
+
+---
+
+## Known Limitations
+
+1. **Quick formative assessment techniques (whiteboards, finger voting) are best suited for checking procedural knowledge and factual recall.** Deeper understanding — why the formula works, when to use it, how it connects to other concepts — requires more time-intensive assessment methods (explanation tasks, extended problems, discussion). This skill recommends the right technique for the moment, but some learning objectives require assessment methods that cannot be completed in 2 minutes.
+
+2. **The response interpretation thresholds (80%, 50–80%, below 50%) are guidelines, not rules.** A class that is 78% correct may be ready to proceed if the 22% who got it wrong all made the same correctable error. A class that is 82% correct may need to pause if the errors suggest a deep misconception. The teacher's professional judgement must interpret the data in context.
+
+3. **Formative assessment only works if the teacher is prepared to adapt.** The technique provides data, but the value is in the response. A teacher who checks whiteboards, sees 60% correct, and proceeds anyway because they need to "get through the lesson" has conducted a formative check but not formative assessment. The willingness to adapt the lesson in response to data is the essential ingredient that no technique can provide.

--- a/skill-library/scope-and-sequence-designer/SKILL.md
+++ b/skill-library/scope-and-sequence-designer/SKILL.md
@@ -1,0 +1,596 @@
+---
+# AGENT SKILLS STANDARD FIELDS (v2)
+name: scope-and-sequence-designer
+category: 教学辅导
+description: >-
+  设计课程的范围与进度(scope & sequence):跨年级、跨学期的纵向进阶与横向衔接,含先修依赖、知识类型诊断、硬性与建议的排序约束、逐条带理由的教学顺序与连贯性检查。搭建新课程、重构学科体系或梳理进阶路径时使用。触发词:课程规划, 教学进度表, 课程大纲, 学期教学计划, 知识点顺序, 单元排布, 课程体系, 进阶路径; scope and sequence, curriculum map, progression.
+disable-model-invocation: false
+user-invocable: true
+effort: medium
+
+# EXISTING FIELDS
+
+skill_id: "curriculum-assessment/scope-and-sequence-designer"
+skill_name: "Scope and Sequence Designer"
+domain: "curriculum-assessment"
+version: "1.1"
+evidence_strength: "moderate"
+evidence_sources:
+  - "Bruner (1960) — The Process of Education: spiral curriculum and vertical coherence"
+  - "Wiggins & McTighe (2005) — Understanding by Design: backwards design applied to programme-level planning"
+  - "Bernstein (1999) — Vertical and horizontal discourse: hierarchical knowledge sequencing"
+  - "Hattie (2009) — Visible Learning: curriculum coherence as a high-effect variable"
+  - "Muller (2009) — Forms of knowledge and curriculum coherence: conceptual vs contextual coherence"
+  - "Maton (2013) — Making semantic waves: cumulative knowledge-building across a programme"
+  - "Schmidt, Wang & McKnight (2005) — Coherence of the intended, implemented, and attained curriculum"
+  - "Duschl, Schweingruber & Shouse (2007) — Taking Science to School: learning progressions as programme architecture"
+  - "Kolb (1984) — Experiential Learning: experience as prerequisite for dispositional development"
+  - "Bransford, Brown & Cocking (2000) — How People Learn: experiential readiness and conceptual framing"
+  - "Flavell (1979) — Metacognition and cognitive monitoring: naming before practising metacognitive strategies"
+  - "Kirschner, Sweller & Clark (2006) — Why minimal guidance during instruction does not work: explicit instruction for novices"
+input_schema:
+  required:
+    - field: "subject_or_programme"
+      type: "string"
+      description: "Name and brief description of the subject or programme"
+    - field: "developmental_bands"
+      type: "string"
+      description: "The band, year group, or stage structure used by the school or programme (e.g. Band A–D, Years 1–13, Foundation through Diploma, early childhood through upper secondary, or any other developmental architecture the school uses — this skill is not constrained to any particular system or age range)"
+    - field: "intended_outcomes"
+      type: "string"
+      description: "The overarching goals students should reach by the end of the programme"
+  optional:
+    - field: "existing_units_or_competencies"
+      type: "string"
+      description: "Any existing units, competencies, or LTs already in place"
+    - field: "knowledge_architecture_output"
+      type: "string"
+      description: "From curriculum-knowledge-architecture-designer if already run"
+    - field: "time_available"
+      type: "string"
+      description: "Hours or lessons per week per band"
+    - field: "kud_charts"
+      type: "string"
+      description: "KUD charts (Know/Understand/Do per band) for the LTs being sequenced. Richest input for prerequisite inference. Know layer reveals T1 content dependencies. Understand layer reveals conceptual scaffold relationships. Do layer reveals T3 vs T1/T2 distinctions. High confidence inference. Supply as markdown table or structured text."
+    - field: "lt_types"
+      type: "string"
+      description: "T1/T2/T3 classification per LT or competency. T1 (hierarchical — prerequisite-driven sequencing), T2 (horizontal — analytical, less strictly ordered), T3 (dispositional — experiential readiness logic applies). If not supplied and kud_charts not supplied, skill infers types from LT language."
+    - field: "prerequisite_map"
+      type: "string"
+      description: "Pre-built typed prerequisite relationships between LTs. Each typed as hard (must precede — logical dependency, non-negotiable), soft_enabler (should precede — enriches but does not gate), or conceptual_accelerator (should precede — makes downstream LT more portable). If supplied, used directly without inference."
+    - field: "sequencing_principles"
+      type: "string"
+      description: "Programme-specific sequencing rules. e.g. 'T3 experience before T1 explanation', 'LT 6.1 early as conceptual accelerator for C1 and C3 LTs'. These override the skill's default logic where they conflict."
+output_schema:
+  type: "object"
+  fields:
+    - field: "knowledge_progression_map"
+      type: "object"
+      description: "For each knowledge type (hierarchical, horizontal, dispositional): how it develops across bands, what is introduced when, and what the prerequisite dependencies are between bands"
+    - field: "vertical_coherence_check"
+      type: "object"
+      description: "For hierarchical knowledge: are prerequisites in place before each new concept is introduced? For horizontal knowledge: is sophistication of thinking increasing across bands? For dispositional knowledge: are development opportunities present and cumulative across the full programme?"
+    - field: "horizontal_coherence_check"
+      type: "object"
+      description: "Within each band: is there appropriate balance between knowledge types? Are the units within the band connected or siloed?"
+    - field: "sequencing_rationale"
+      type: "string"
+      description: "For each LT placement, one sentence explaining which sequencing logic drove the decision: hard prerequisite / soft scaffold / experiential readiness / supplied principle / no dependency."
+    - field: "gaps_and_overlaps"
+      type: "object"
+      description: "Elements that are missing from the sequence, elements that are repeated without adding sophistication, and band transitions where students are likely to struggle"
+    - field: "design_flags"
+      type: "object"
+      description: "Compound competencies that span multiple bands without clear progression logic, dispositional goals without sufficient knowledge prerequisites, and horizontal elements without explicit thinking development"
+    - field: "inferred_prerequisite_map"
+      type: "array"
+      description: "Present when no prerequisite_map supplied. Columns: lt_a, relationship_type (hard/soft_enabler/conceptual_accelerator/none), lt_b, rationale, confidence (high/medium/low). Flagged as inferred — requires subject expert and teacher review before treating as authoritative."
+    - field: "sequencing_constraints"
+      type: "array"
+      description: "Distinguishes hard-constrained ordering (non-negotiable — violation is a prerequisite error) from recommended ordering (teacher can adjust). Columns: lt_or_competency, constraint_type (hard/recommended), rationale."
+    - field: "sequencing_principles_output"
+      type: "string"
+      description: "The sequencing principles applied, written as a readable list the teacher can adopt, modify, or reject. Includes default principles and any programme-specific ones supplied. Makes the skill's reasoning transparent and adjustable."
+    - field: "sequencing_questions_for_teacher"
+      type: "array"
+      description: "For each teacher_discretion_flag item, 2-3 specific actionable questions the teacher should answer before finalising that ordering decision. Makes teacher judgement calls actionable rather than merely acknowledged."
+    - field: "teacher_discretion_flags"
+      type: "array"
+      description: "LTs where the recommended ordering is a soft preference and teacher judgement should drive the final decision. Includes all T3 dispositional LTs where experiential readiness is context-dependent."
+    - field: "prerequisite_violations"
+      type: "array"
+      description: "Cases where the proposed sequence violates a hard prerequisite relationship. Empty array if none. Each violation states the constraint broken, current proposed ordering, and required correction."
+    - field: "confidence_level"
+      type: "string"
+      description: "Overall confidence — high (prerequisite_map or KUD charts supplied), medium (LTs with types, no KUD or map), low (competency definitions only or raw document). Includes one sentence on what would raise confidence."
+chains_well_with:
+  - "curriculum-knowledge-architecture-designer"
+  - "kud-knowledge-type-mapper"
+  - "kud-chart-author"
+  - "learning-target-authoring-guide"
+  - "developmental-band-system-designer"
+  - "backwards-design-unit-planner"
+  - "competency-unpacker"
+  - "learning-progression-builder"
+  - "gap-analysis-from-student-work"
+teacher_time: "15 minutes"
+tags: ["scope-and-sequence", "curriculum-coherence", "vertical-coherence", "learning-progressions", "programme-design", "Bruner", "spiral-curriculum", "knowledge-types", "prerequisite-sequencing", "KUD-charts"]
+---
+
+# Scope and Sequence Designer
+
+## What This Skill Does
+
+Takes a programme description and developmental band structure and produces a coherent scope and sequence — mapping what gets taught across all bands, in what order, with explicit reasoning for the sequencing decisions. This skill works at any level of education: early childhood through upper secondary, undergraduate, professional development programmes, or any other staged learning architecture. Most scope and sequence documents are lists: topics assigned to year groups without coherent logic for why that topic sits there, what it builds on, or what it prepares students for. This skill produces a structured progression grounded in three knowledge types: hierarchical elements are sequenced by prerequisite logic so foundational knowledge is always in place before the next layer is introduced; horizontal elements are sequenced to build thinking sophistication progressively rather than repeating the same thinking moves at the same level year after year; dispositional elements are mapped as continuous threads with explicit identification of the knowledge prerequisites that must be in place before a disposition can meaningfully develop. When KUD charts, LT types, or a pre-built prerequisite map are supplied, the skill applies them directly; when they are not, it infers prerequisite relationships and flags the confidence of every inference. The result is a programme where every element has a defensible reason for being where it is — and where the epistemic status of each recommendation is explicit. AI is specifically valuable here because coherent programme design requires simultaneously tracking prerequisite chains across years, monitoring knowledge type balance within and across bands, and identifying gaps and overlaps that are invisible when looking at individual units in isolation — a level of systematic cross-referencing that is cognitively demanding and frequently skipped in real curriculum planning.
+
+## Evidence Foundation
+
+Bruner (1960) established the foundational principle of the spiral curriculum: key ideas should be revisited across year groups at increasing levels of sophistication, with each encounter building on prior encounters rather than repeating them. A scope and sequence that revisits a topic without increasing the cognitive demand is not a spiral — it is repetition. The spiral principle applies differently to the three knowledge types. Hierarchical knowledge spirals by adding new layers of complexity on top of secured foundations — fractions before algebra, cell biology before genetics. Horizontal knowledge spirals by increasing the sophistication of analytical thinking applied to recurring themes — a student who identifies perspectives at Band A should be evaluating and comparing analytical frameworks at Band D. Dispositional knowledge does not spiral in the same way — it develops continuously through enacted practice across the full programme, though the knowledge that supports dispositional expression deepens at each band.
+
+Schmidt, Wang & McKnight (2005) analysed curriculum coherence across high-performing education systems and found that coherent curricula share three features: **focus** (fewer topics taught more deeply), **rigour** (appropriate challenge at each level), and **coherence** (topics connect logically within and across years). Systems that lack coherence — where topics appear and disappear without progression logic — consistently underperform. Their most significant finding for scope and sequence design is that coherence is not just a vertical property (does Band B build on Band A?) but also a horizontal property (do the elements within Band B connect to each other?). A programme can have perfect vertical sequencing and still lack coherence if the units within each band are isolated from each other.
+
+Duschl, Schweingruber & Shouse (2007) developed the concept of **learning progressions**: empirically grounded descriptions of how student understanding develops across years, with each level building specifically on the previous one. Their work establishes that progression is not automatic — it requires deliberate curriculum design that matches what is taught to what students are ready to learn. Learning progressions are best documented for hierarchical knowledge domains (mathematics, early reading, some areas of science), where the prerequisite structure is well-researched. For horizontal and dispositional domains, progressions are less empirically established and must be constructed from developmental principles rather than from replicated research on specific learning sequences.
+
+Wiggins & McTighe (2005) applied backwards design to programme-level planning: begin with the intended outcomes at the end of the programme, then work backwards to determine what must be in place at each stage to reach those outcomes. At the scope and sequence level, this means the final band's expectations determine what must be taught in every preceding band — not as direct preparation for a test, but as the knowledge and capability foundations that make the final outcomes achievable.
+
+Bernstein (1999) and Muller (2009) establish the theoretical foundation for knowledge-type-specific sequencing. **Hierarchical knowledge** has an inherent sequencing logic: concepts must be taught in prerequisite order because later concepts genuinely depend on earlier ones. You cannot teach genetic inheritance before students understand cell division. **Horizontal knowledge** does not have prerequisite chains in the same way — different analytical lenses can be introduced in various orders — but it does have a sophistication progression: students should move from identifying perspectives to analysing through perspectives to evaluating and synthesising across perspectives. Sequencing horizontal knowledge by increasing analytical demand rather than by prerequisite dependency is one of the key distinctions this skill makes.
+
+Maton (2013) adds the semantic wave concept: effective knowledge-building requires movement between abstract principles and concrete cases across a programme, not just within individual lessons. A scope and sequence that stays at the abstract level throughout produces disconnected theoretical knowledge; one that stays at the concrete level produces experience without conceptual development. Across a programme, the semantic profile should show increasing capacity to move between concrete and abstract — students at early bands work primarily with concrete cases and simple abstractions, while students at later bands should be able to operate fluently at multiple levels of abstraction and move between them deliberately.
+
+Hattie (2009) identified curriculum coherence as a high-effect variable in student achievement. Programmes where students experience learning as a connected, cumulative journey produce better outcomes than programmes where each year feels like a fresh start with new content that does not obviously connect to what came before. This is the practical justification for investing in scope and sequence design: the coherence of the programme is a stronger predictor of student outcomes than the quality of any individual unit within it.
+
+Bransford, Brown & Cocking (2000) and Kolb (1984) establish the experiential readiness principle for dispositional sequencing: students who have practised a disposition encounter the explanation of it as confirmation of lived experience rather than abstraction. Experience should generally precede explanation for social-emotional dispositional capabilities. Flavell (1979) introduces an important exception: for metacognitive and reflective LTs, naming strategies explicitly before practising them improves practice quality. Kirschner, Sweller & Clark (2006) provide the counterpoint that novice learners benefit from explicit instruction before practice in many domains — this skill acknowledges the tension and flags it for teacher discretion wherever it applies.
+
+## Input Schema
+
+The educator must provide:
+- **Subject or programme:** Name and brief description. *e.g. "Wellbeing, REAL School Budapest" / "Science, Years 7–13" / "Interdisciplinary Humanities, Foundation through Diploma" / "Early Childhood Mathematics, ages 3–6"*
+- **Developmental bands:** The band, year group, or stage structure. *e.g. "Bands A–D (approximately ages 5–15)" / "Years 7–13" / "Foundation, Intermediate, Advanced, Diploma" / "Nursery, Reception, Year 1, Year 2"*
+- **Intended outcomes:** The overarching goals students should reach by the end of the programme. *e.g. "Students develop self-regulation, agency, care for others, and the scientific literacy to understand their own wellbeing" / "Students develop scientific reasoning, experimental design capability, and the knowledge base for further study at university level"*
+
+Optional (injected by context engine if available):
+- **Existing units or competencies:** Any existing units, competencies, or LTs already in place
+- **Knowledge architecture output:** From curriculum-knowledge-architecture-designer if already run
+- **Time available:** Hours or lessons per week per band
+- **KUD charts:** KUD charts (Know/Understand/Do per band) for the LTs being sequenced. Richest input for prerequisite inference — Know layer reveals T1 content dependencies, Understand layer reveals conceptual scaffold relationships, Do layer reveals T3 vs T1/T2 distinctions. High confidence inference.
+- **LT types:** T1/T2/T3 classification per LT or competency. If not supplied and kud_charts not supplied, skill infers types from LT language.
+- **Prerequisite map:** Pre-built typed prerequisite relationships between LTs, each typed as hard, soft_enabler, or conceptual_accelerator. If supplied, used directly without inference.
+- **Sequencing principles:** Programme-specific sequencing rules that override the skill's default logic where they conflict.
+
+## Prompt
+
+```
+You are a curriculum sequencing specialist producing scope and sequence recommendations for competency-based developmental band programmes. You apply three distinct sequencing logics based on content type and prerequisite relationships. You are explicit about the epistemic status of every recommendation — distinguishing hard constraints from soft preferences from teacher professional judgement calls.
+
+---
+
+STEP 0 — INPUT ASSESSMENT AND ROUTING
+
+Assess input state before producing any output:
+
+STATE A — prerequisite_map supplied: Use directly. Highest confidence. Proceed.
+
+STATE B — kud_charts supplied (no prerequisite_map): Infer from KUD charts. High confidence. Proceed.
+
+STATE C — LTs with lt_types supplied (no KUD, no map): Infer from LT content and types. Medium confidence. Proceed with confidence flags.
+
+STATE D — only competency definitions supplied: Low confidence. Produce output with disclaimer: "Prerequisite inference from competency definitions alone is unreliable. Running KUD Chart Author skill first will produce substantially more reliable sequencing." Proceed with low confidence flagged throughout.
+
+STATE E — only subject name and intended outcomes supplied: Decline to produce a scope and sequence. Output: "Insufficient inputs for reliable sequencing. Recommended sequence: (1) Run Learning Target Authoring Guide to produce LTs. (2) Run KUD Chart Author to produce KUD charts. (3) Return here." Do not produce a sequence in State E.
+
+---
+
+STEP 1 — PREREQUISITE MAP
+
+1a. If prerequisite_map supplied: use directly. Skip to Step 2.
+
+1b. Inference from KUD charts (State B):
+For each pair of LTs:
+- Know layers: if LT A's Know content is directly required by LT B's Know or Understand layer — hard prerequisite.
+- Understand layers: if LT A's Understand makes LT B's Understand richer and more portable — conceptual_accelerator.
+- Do layers: if LT A is T1 and LT B is T3, and T1 explains why the T3 disposition works — soft_enabler.
+- No meaningful dependency — none.
+Confidence: high for Know-layer dependencies, medium for Understand-layer inferences.
+
+1c. Inference from LT content and types (State C). Apply by type combination:
+
+T1 → T1: Would a student lacking LT A's content be unable (not just hindered) to access LT B? If yes: hard. If enriching but not gating: soft_enabler. Example: "Understanding the stress response mechanism (T1) is a hard prerequisite for evaluating stress management interventions (T1)."
+
+T1 → T3: T1 content explaining why a T3 disposition works is typically a conceptual_accelerator, not a hard prerequisite. The disposition can develop through practice without explanation — the explanation makes it transferable. Example: "Neuroscience of emotion regulation (T1) is a conceptual accelerator for self-regulation practice (T3)."
+
+T2 → T3: Typically a soft_enabler. Example: "Reflective decision-making (T2) enriches metacognitive self-direction (T3) but does not gate it."
+
+T3 → T3: Usually soft. One T3 disposition rarely makes another logically inaccessible. Example: "Self-awareness (T3) is a soft enabler for empathy (T3)."
+
+T2 → T2: Rarely hard prerequisites — usually parallel. Flag as none unless clear content dependency exists.
+
+Confidence for all State C inferences: medium.
+
+1d. Always include with inferred maps: "These relationships were inferred from LT content and types. Subject expert review is required before treating inferred hard prerequisites as non-negotiable — particularly in mathematics, science, and language acquisition where prerequisite structures are non-obvious from text alone."
+
+---
+
+STEP 2 — THREE SEQUENCING LOGICS
+
+HARD PREREQUISITE LOGIC
+Applies to: T1 LTs with hard prerequisites in the map.
+Rule: prerequisite LT must appear earlier. Non-negotiable. Violation = PREREQUISITE_VIOLATION error, not a suggestion.
+Output: constraint_type: hard in sequencing_constraints.
+
+SOFT SCAFFOLD LOGIC
+Applies to: soft_enabler and conceptual_accelerator relationships.
+Rule: place enabler/accelerator earlier where possible. When not possible, flag the trade-off in sequencing_rationale.
+Output: constraint_type: recommended. Teacher can adjust.
+
+EXPERIENTIAL READINESS LOGIC
+Applies to: T3 dispositional LTs.
+Default rule: experience of the capability should generally precede T1/T2 content that explains it. Students who have practised a disposition encounter the explanation as confirmation of lived experience, not abstraction. (Bransford, Brown & Cocking (2000). How People Learn. National Academies Press. Kolb (1984). Experiential Learning. Prentice Hall.)
+
+Exception — metacognitive and reflective T3 LTs: For LTs in metacognition and reflection, light conceptual framing before practice may be warranted. Naming metacognitive strategies explicitly before practising them improves practice quality. (Flavell (1979). Metacognition and cognitive monitoring. American Psychologist, 34(10), 906-911.) Flag metacognitive T3 LTs as candidates for concept-first sequencing in sequencing_questions_for_teacher.
+
+Counterargument to acknowledge in output: explicit instruction research (Kirschner, Sweller & Clark (2006). Why minimal guidance during instruction does not work. Educational Psychologist, 41(2), 75-86.) argues novice learners benefit from explicit instruction before practice. Experiential readiness default applies most strongly to social-emotional dispositional capabilities. Do not apply to T1 LTs.
+
+Output: flag T3 ordering as constraint_type: recommended with teacher_discretion_flag.
+
+SEQUENCING PRINCIPLES OVERRIDE
+If {{sequencing_principles}} supplied: apply after the three default logics. Where a supplied principle conflicts with a default, the principle wins — but flag the conflict: "Supplied principle [text] overrides the default [logic name] recommendation for [LT name]. If intentional, no action needed. If not, review the supplied principle."
+
+---
+
+STEP 3 — KNOWLEDGE ARCHITECTURE DIAGNOSIS
+
+Before producing the full sequence, identify what types of knowledge are present in this programme. If a knowledge architecture output is provided, use it. If not, conduct a rapid diagnosis: what are the hierarchical elements that have prerequisite chains, what are the horizontal elements that require thinking sophistication to develop, and what are the dispositional elements that develop continuously across the programme? List the major elements under each type. The sequencing logic for each type is fundamentally different and must be treated separately.
+
+---
+
+STEP 4 — FULL SEQUENCE CONSTRUCTION
+
+Apply the three sequencing logics from Step 2 to place every LT or competency in a band. For each placement:
+- State the constraint_type: hard or recommended
+- State the sequencing_rationale in one sentence: which logic drove the decision
+- Flag any teacher_discretion items (all T3 ordering, all soft scaffold decisions)
+
+---
+
+STEP 5 — COHERENCE CHECKS
+
+VERTICAL COHERENCE: For hierarchical elements: is every concept introduced after its prerequisites are secured? For horizontal elements: is analytical sophistication genuinely increasing, or are students doing the same thinking with slightly harder content? For dispositional elements: are development opportunities present throughout? Flag every break.
+
+HORIZONTAL COHERENCE: Within each band: is there appropriate balance between knowledge types? Are units connected or siloed? Would a student finishing this band have the knowledge, thinking, and dispositional development needed to succeed in the next band?
+
+---
+
+STEP 6 — SEQUENCING PRINCIPLES OUTPUT
+
+Write a readable list of principles applied:
+- The three default logics, stated plainly
+- Any programme-specific principles supplied
+- The metacognitive T3 exception
+- Invitation: "Review these principles. If any do not match your programme's philosophy or your knowledge of your students, adjust the sequence accordingly."
+
+---
+
+STEP 7 — SEQUENCING QUESTIONS FOR TEACHER
+
+For each teacher_discretion_flag item, produce 2-3 specific actionable questions. Examples:
+
+For T3 LT ordering:
+- "Have students in this band encountered [capability] in practice already through projects or earlier band experience?"
+- "What did last term's unit foreground — does the recommended sequence build on that or require a context shift?"
+- "Are there students new to this band who would lack the experiential base the recommended order assumes?"
+
+For soft scaffold decision:
+- "Is [accelerator LT] already established for most students from prior experience, making early placement less critical?"
+
+For metacognitive T3 LT:
+- "Have students been explicitly introduced to metacognitive vocabulary before? If yes, experience-first may be less important."
+- "Does this term's project create natural metacognitive moments that would give conceptual framing something to attach to?"
+
+---
+
+STEP 8 — DESIGN FLAGS AND RECOMMENDATIONS
+
+Identify gaps (important elements missing from the sequence), overlaps (elements repeated without progression), transitions where students are likely to struggle, and compound competencies that appear to span multiple bands without clear progression logic. For each flag, provide a specific recommendation.
+
+---
+
+STEP 9 — INPUTS
+
+subject_or_programme: {{subject_or_programme}}
+developmental_bands: {{developmental_bands}}
+intended_outcomes: {{intended_outcomes}}
+existing_units_or_competencies: {{existing_units_or_competencies}}
+kud_charts: {{kud_charts}}
+lt_types: {{lt_types}}
+prerequisite_map: {{prerequisite_map}}
+sequencing_principles: {{sequencing_principles}}
+time_available: {{time_available}}
+knowledge_architecture_output: {{knowledge_architecture_output}}
+
+---
+
+Return your output in this exact format:
+
+## Scope and Sequence: [Programme Name]
+
+**Programme:** [Summarised]
+**Developmental bands:** [Band structure]
+**Intended outcomes:** [Summarised]
+**Time available:** [If provided; otherwise "Not specified"]
+**Input state:** [A/B/C/D — one sentence on what was supplied and confidence level]
+
+### Confidence Level
+
+[Overall confidence — high/medium/low — with one sentence on what would raise confidence]
+
+### 0. Prerequisite Map
+
+[If prerequisite_map supplied: "Using supplied map." List relationships.]
+[If inferred: table with columns lt_a | relationship_type | lt_b | rationale | confidence]
+[Always include inferred-map disclaimer if applicable]
+
+### 1. Knowledge Architecture Diagnosis
+
+**Hierarchical elements:**
+[List with brief description of each]
+
+**Horizontal elements:**
+[List with brief description of each]
+
+**Dispositional elements:**
+[List with brief description of each]
+
+**Architecture summary:**
+[Overall profile — what proportion of the programme is hierarchical, horizontal, and dispositional, and what does this mean for sequencing]
+
+### 2. Sequencing Constraints
+
+| LT or Competency | Constraint Type | Rationale |
+|---|---|---|
+| [LT] | hard / recommended | [One sentence] |
+
+### 3. Recommended Sequence with Rationale
+
+[For each LT or competency: band placement, sequencing_rationale (one sentence per item), teacher_discretion_flag if applicable]
+
+### 4. Prerequisite Violations
+
+[Empty if none: "No prerequisite violations detected."]
+[If present: violation, current proposed ordering, required correction]
+
+### 5. Coherence Checks
+
+**Vertical coherence:**
+[Hierarchical / horizontal / dispositional — flag breaks]
+
+**Horizontal coherence:**
+[Per band — balance, connections, readiness for next band]
+
+### 6. Sequencing Principles
+
+[Readable list — default logics, programme-specific principles, metacognitive T3 exception, invitation to adjust]
+
+### 7. Teacher Discretion Flags and Questions
+
+[For each flagged item: the flag, then 2-3 specific actionable questions]
+
+### 8. Design Flags and Recommendations
+
+**Gaps:** [Missing elements — with recommendation]
+**Overlaps:** [Repeated without progression — with recommendation]
+**Difficult transitions:** [With recommendation]
+**Compound competencies:** [With recommendation]
+**Priority actions:** [3–5 highest-impact changes, in order]
+
+**Self-check before returning output:** Verify that (a) input state is assessed before any output is produced and State E is declined, (b) every hard prerequisite has constraint_type: hard and a prerequisite_violations check is included, (c) every T3 dispositional ordering is flagged for teacher discretion, (d) the metacognitive T3 exception is identified where relevant, (e) the inferred prerequisite map disclaimer is included whenever inference was used, (f) the sequencing_principles output makes the skill's reasoning transparent and adjustable, (g) sequencing questions are specific and actionable (not generic), and (h) confidence_level is stated with a clear statement of what would raise it.
+```
+
+## Example Output
+
+**Scenario:** *Subject or programme: "Wellbeing, REAL School Budapest" / Developmental bands: "Bands A–D (approximately ages 5–15)" / Intended outcomes: "Students develop self-regulation, agency, care for others, and the scientific literacy to understand their own wellbeing" / Existing units or competencies: "Existing competencies: Self-Awareness & Regulation, Health Literacy & Habits, Reflective Thinking & Decision-Making, Social Awareness & Empathy, Communication & Collaboration. New competency being added: Wellbeing Science & Literacy (hierarchical knowledge of neuroscience, stress response, habits science)"*
+
+---
+
+## Scope and Sequence: Wellbeing, REAL School Budapest
+
+**Programme:** Wellbeing — self-regulation, agency, care for others, scientific literacy for understanding own wellbeing
+**Developmental bands:** Bands A–D (approximately ages 5–15)
+**Intended outcomes:** Students develop self-regulation, agency, care for others, and the scientific literacy to understand their own wellbeing
+**Time available:** Not specified
+**Input state:** State D — competency definitions supplied without KUD charts, LT types, or prerequisite map. Medium-low confidence. Supplying KUD charts via KUD Chart Author would substantially improve sequencing reliability.
+
+### Confidence Level
+
+Medium-low. Prerequisite relationships inferred from competency definitions and knowledge domain conventions. Supplying KUD charts (Know/Understand/Do per band) would raise confidence to high for hierarchical relationships. Subject expert review required for all inferred hard prerequisites before treating them as non-negotiable.
+
+### 0. Prerequisite Map
+
+*Inferred from competency definitions and knowledge domain. Subject expert review required — particularly for neuroscience prerequisites, which are non-obvious from competency text alone.*
+
+| LT / Concept | Relationship | LT / Concept | Rationale | Confidence |
+|---|---|---|---|---|
+| Body awareness | hard | Fight-flight-freeze | Cannot understand automatic physical stress responses without first noticing physical sensations | High |
+| Fight-flight-freeze | hard | Autonomic nervous system | ANS content assumes the concept of automatic stress responses is established | High |
+| Autonomic nervous system | hard | HPA axis | HPA axis extends the ANS model — cannot teach neuroendocrine pathway without the ANS concept | High |
+| Basic brain awareness | hard | Amygdala & threat detection | Amygdala content requires prior concept that brain structures underlie emotional responses | High |
+| Habits science | conceptual_accelerator | Health Literacy & Habits (dispositional) | Habits science makes dispositional habit practice more portable and self-directed | Medium |
+| Autonomic nervous system | conceptual_accelerator | Self-Awareness & Regulation | Knowing WHY calming techniques work makes strategy selection more transferable | Medium |
+| Reflective Thinking & Decision-Making | soft_enabler | Agency | Reflective capacity enriches agentic decision-making but does not gate early agency expression | Medium |
+| Self-Awareness & Regulation | soft_enabler | Care for others | Developed self-awareness makes noticing others' states more reliable, but care can begin before regulation is mature | Medium |
+
+### 1. Knowledge Architecture Diagnosis
+
+**Hierarchical elements:**
+- **Wellbeing Science & Literacy** (new competency): Neuroscience of the stress response, brain structures involved in emotional processing, the HPA axis, cortisol and adrenaline pathways, the autonomic nervous system (sympathetic/parasympathetic), the physiological basis of calming techniques, habits science (cue-routine-reward loop, neuroplasticity), sleep science, nutrition and wellbeing connections
+- **Health Literacy & Habits** (existing competency, partially hierarchical): Factual knowledge about physical health — nutrition basics, sleep hygiene, exercise science — that has right/wrong answers and prerequisite chains
+
+**Horizontal elements:**
+- **Reflective Thinking & Decision-Making** (existing competency): Analysing situations through multiple lenses, weighing competing considerations, evaluating the quality of one's own reasoning — thinking sophistication must increase across bands
+- **Social Awareness & Empathy** (existing competency, partially horizontal): Understanding different perspectives, recognising that emotional responses are influenced by context, history, and interpretation — perspectival knowledge that deepens through analytical sophistication
+- **Communication & Collaboration** (existing competency, partially horizontal): The quality of collaborative thinking, conflict resolution reasoning, and communication strategy must become more sophisticated, not just more frequent
+
+**Dispositional elements:**
+- **Self-Awareness & Regulation** (existing competency): Enacted self-regulation — noticing emotional escalation and choosing a response rather than reacting. This is a disposition, not a skill: it exists in patterns of behaviour over time, not in task performance
+- **Agency** (intended outcome, not yet a named competency): The orientation toward taking purposeful action — not compliance and not defiance, but self-directed engagement with challenges. Develops as a continuous thread
+- **Care for others** (intended outcome, not yet a named competency): The interpersonal disposition to notice and respond to others' wellbeing. Not the same as social awareness (which is partly horizontal knowledge) — care is enacted, not analysed
+- **Health Literacy & Habits** (existing competency, partially dispositional): The habit dimension — actually maintaining routines that support wellbeing, as distinct from knowing what the routines should be
+
+**Architecture summary:**
+This programme is a **mixed architecture with a significant dispositional core and a new hierarchical strand**. The five existing competencies are primarily dispositional and horizontal — they describe ways of being and ways of thinking, not factual knowledge to be acquired. The addition of Wellbeing Science & Literacy introduces a genuinely hierarchical strand with prerequisite chains that must be respected. The central design challenge is connecting the hierarchical knowledge (neuroscience, stress science, habits science) to the dispositional goals (self-regulation, agency, care) — the science is not an end in itself but the knowledge foundation that makes the dispositions more informed, more intentional, and more effective.
+
+### 2. Sequencing Constraints
+
+| LT or Competency | Constraint Type | Rationale |
+|---|---|---|
+| Body awareness → Fight-flight-freeze | hard | Physical sensation awareness is logically required to understand automatic physical stress responses |
+| Fight-flight-freeze → Autonomic nervous system | hard | ANS content builds directly on the established concept of automatic arousal |
+| Autonomic nervous system → HPA axis | hard | Neuroendocrine pathway requires ANS concept as foundation |
+| Basic brain awareness → Amygdala content | hard | Brain structure content requires the prior concept that emotions have a neural basis |
+| Self-Awareness & Regulation (experiential, early bands) before ANS content | recommended | Experiential readiness logic — practised regulation encounters the explanation as confirmation, not abstraction |
+| Habits science before Health Literacy & Habits (informed practice, Band D) | recommended | Conceptual accelerator — habits science makes dispositional practice more self-directed |
+| Reflective Thinking before meta-reflective Agency | recommended | Soft enabler — reflective capacity enriches but does not gate early agency |
+
+### 3. Recommended Sequence with Rationale
+
+**Band A:**
+- Body awareness — *Hard prerequisite foundation: no prior concept required; directly observable; entry point for all wellbeing science*
+- Basic brain awareness — *Hard prerequisite: follows body awareness; age-appropriate framing that prepares amygdala content*
+- Emotions vocabulary — *Hard prerequisite chain: builds on body awareness; more nuanced vocabulary requires basic awareness*
+- Self-Awareness & Regulation (emergent, experiential) — *Experiential readiness: disposition practice begins before explanation; experience-first is correct for T3 social-emotional LTs* ⚑ teacher discretion
+- Care for others (emergent) — *Experiential readiness: enacted care begins as prompted kindness before contextual understanding* ⚑ teacher discretion
+- Agency (emergent) — *Experiential readiness: early choice-making experience precedes reflective framing* ⚑ teacher discretion
+
+**Band B:**
+- Fight-flight-freeze response — *Hard prerequisite logic: body awareness secured at Band A; fight-flight-freeze concept requires it*
+- Reflective Thinking (Developing level) — *Sophistication progression: moves from identifying choices (A) to reasoning about consequences (B)*
+- Social Awareness & Empathy (Developing level) — *Sophistication progression: from recognising emotions in others (A) to recognising others feel differently (B)*
+- Self-Awareness & Regulation (understanding automatic reactions) — *Conceptual accelerator from fight-flight-freeze: practice becomes more informed; still recommended not hard* ⚑ teacher discretion
+
+**Band C:**
+- Amygdala & threat detection — *Hard prerequisite logic: fight-flight-freeze and basic brain awareness both secured; introduces specific neural structure*
+- Autonomic nervous system — *Hard prerequisite logic: fight-flight-freeze secured; ANS content explains why techniques work — must precede informed regulation expectations*
+- Habits science — *Hard prerequisite logic: basic brain awareness secured; neuroplasticity concept accessible at this band*
+- Self-Awareness & Regulation (science-informed, strategy selection) — *Conceptual accelerator activated: ANS content must precede this expectation — teach ANS first in Band C, then move to informed strategy selection*
+- Reflective Thinking (Competent level) — *Sophistication progression: weighing competing considerations*
+- Social Awareness (Competent level) — *Sophistication progression: contextual analysis of emotional responses*
+
+**Band D:**
+- HPA axis and acute vs chronic stress — *Hard prerequisite logic: ANS and amygdala both secured; completes the neuroendocrine pathway*
+- Sleep science — *Hard prerequisite logic: ANS concept required to explain sleep as active physiological process*
+- Self-Awareness & Regulation (distinguishing acute from chronic stress) — *Hard prerequisite logic: HPA axis content must precede this capability*
+- Agency (meta-reflective) — *Soft enabler activated: Reflective Thinking at Extending level enriches but does not fully gate this* ⚑ teacher discretion
+- Reflective Thinking (Extending level — meta-reflective) — *Sophistication progression: thinking about thinking; explicit teaching required* ⚑ teacher discretion
+
+### 4. Prerequisite Violations
+
+No prerequisite violations detected in the recommended sequence above. **Risk to monitor:** If the autonomic nervous system content at Band C is scheduled after the regulation expectation for "informed strategy selection" — within the same band — this would constitute a hard prerequisite violation. Teach ANS content in Term 1 of Band C before moving to science-informed regulation expectations in Term 2.
+
+### 5. Coherence Checks
+
+**Vertical coherence:**
+
+*Hierarchical:* The proposed Wellbeing Science & Literacy prerequisite chain is coherent: body awareness (A) → fight-flight-freeze (B) → amygdala, autonomic nervous system, habits science (C) → HPA axis, acute vs chronic stress, sleep science (D). Each concept builds on the previous. Risk: density at Band C — three new hierarchical concepts introduced simultaneously. If time is limited, prioritise autonomic nervous system (it is the prerequisite for the largest number of downstream capabilities).
+
+*Horizontal:* Reflective Thinking, Social Awareness, and Communication & Collaboration show genuine sophistication increases. The critical transition to monitor is Band C → D: all three shift to meta-level thinking. Without explicit teaching of what meta-reflection looks like, students will stay at Band C sophistication with harder content — a plateau, not a spiral.
+
+*Dispositional:* All four dispositional threads are present across all four bands with increasing expectations. Band B risk: dispositional threads develop through practice alone, without knowledge support. Self-Regulation at Band B is practice-based ("use these techniques because they work"), not science-informed. This is developmentally appropriate — the knowledge arrives at Band C — but teachers must understand that the transition to informed regulation happens at Band C, not before.
+
+**Horizontal coherence:**
+
+*Band A:* Primarily dispositional and concrete experiential. Hierarchical content minimal. Horizontal at Emerging level. Balance is developmentally appropriate. Internal connections are strong — body awareness, emotions vocabulary, noticing others' emotions, and simple regulation strategies are naturally linked through embodied experience.
+
+*Band B:* Dispositional threads continue. One new hierarchical concept (fight-flight-freeze). Horizontal at Developing level. Balance appropriate but hierarchical strand is thin — one concept must be taught with sufficient depth to justify its placement. Connection between scientific concept and dispositional practice needs to be made explicit by teachers.
+
+*Band C:* Most demanding band. Three new hierarchical concepts, horizontal at Competent level, dispositional expectations now science-informed. Risk of overload. Internal connections are potentially strong but span competencies — if competencies are taught in isolation, students will not see the connections. Recommend at least one cross-competency unit explicitly connecting ANS science to regulation practice.
+
+*Band D:* All three types at maximum demand. Internal connections are strongest if made explicit: HPA axis → chronic stress → habits → agency → care for others with respect for autonomy forms a coherent synthesis. If taught as separate units, it fragments.
+
+### 6. Sequencing Principles
+
+The following principles were applied in producing this sequence. Review them. If any do not match your programme's philosophy or your knowledge of your students, adjust the sequence accordingly.
+
+**Default principles applied:**
+
+1. **Hard prerequisite logic (T1):** Where LT B genuinely cannot be accessed without LT A's content, LT A is placed earlier. These constraints are non-negotiable — reordering them produces prerequisite violations.
+
+2. **Soft scaffold logic:** Where LT A enriches or makes LT B more transferable without fully gating it, LT A is placed earlier as a recommendation. Teachers can adjust soft scaffold ordering based on student readiness.
+
+3. **Experiential readiness logic (T3):** For social-emotional dispositional capabilities, experience of the capability generally precedes the T1/T2 content that explains it. Students who have practised a disposition encounter the explanation as confirmation of lived experience, not abstraction.
+
+**Exception applied:**
+
+4. **Metacognitive T3 exception:** For metacognitive and reflective LTs, light conceptual framing before practice may improve practice quality (Flavell, 1979). These LTs are flagged for teacher discretion in Section 7.
+
+**Note on the counterargument:** Explicit instruction research (Kirschner et al., 2006) argues novice learners benefit from explanation before practice in many domains. The experiential readiness default applies most strongly to social-emotional dispositions. For hierarchical knowledge LTs, explicit instruction first is assumed.
+
+### 7. Teacher Discretion Flags and Questions
+
+**Self-Awareness & Regulation — experiential practice beginning at Band A before ANS science**
+
+This placement follows the experiential readiness default: students practise regulation before they can explain why techniques work. This is recommended, not hard-constrained.
+
+- Have students in this band had previous school or home experience with regulation practice? If so, the experiential base is already established and science-first may be a reasonable alternative.
+- Is there a programme-specific reason to introduce the neuroscience concept earlier (e.g. a schoolwide emphasis on body-based learning that would make ANS accessible at Band B)? If yes, supply this as a sequencing principle.
+- Does this school's Band A population include students with significant trauma histories? If so, experience-first regulation practice may be more important, not less — the science can wait.
+
+**Agency and Care for others — beginning at Band A**
+
+Both are recommended to begin as emergent experiential practice at Band A before reflective framing is introduced.
+
+- What does "agency" look like in this school's Band A context — structured choice? student-led projects? If the programme already foregrounds student choice, the experiential base is established.
+- For Care for others: do Band A students already show prosocial behaviour in unstructured settings? If the disposition is already present, the focus is on naming and developing it, not on introducing it from scratch.
+
+**Meta-reflective Reflective Thinking and Agency at Band D**
+
+The shift to thinking-about-thinking is flagged as requiring explicit teaching rather than natural emergence.
+
+- Have students in Band D been explicitly introduced to metacognitive vocabulary before? If yes, the transition to meta-reflection may require less scaffolding.
+- Does this term's project create natural moments for students to observe their own reasoning processes? If so, concept-before-practice may be appropriate — introduce meta-reflection vocabulary before the project begins, then practise it in the project itself.
+- Are there students entering Band D from outside this programme who lack the Band C experiential base? If so, the recommended sequence assumes continuity that may not be present for some students.
+
+### 8. Design Flags and Recommendations
+
+**Gaps:**
+- **Scientific reasoning about evidence** is required at Band D (evaluating wellness claims) but is not included in the Wellbeing Science & Literacy strand. Students need to understand what counts as evidence for a health claim — controlled studies, sample size, correlation vs causation. Either add this to the wellbeing programme or verify it is covered in the science curriculum by Band D.
+- **Agency is not currently a named competency.** The intended outcomes include agency, and it is mapped across all four bands, but it does not appear in the existing competency structure. **Recommendation:** Either add Agency as a sixth competency or ensure it is explicitly embedded within Self-Awareness & Regulation and Reflective Thinking — but if embedded, it must be named and tracked.
+- **Care for others is not currently a named competency.** The Social Awareness & Empathy competency covers the horizontal knowledge dimension but not the dispositional dimension of enacted care. **Recommendation:** Either add Care as a competency or split Social Awareness & Empathy into an analytical strand (horizontal) and an enacted strand (dispositional).
+
+**Overlaps:**
+- **Self-Awareness & Regulation** and **Health Literacy & Habits** overlap in the area of "strategies for managing wellbeing." The distinction — regulation is about emotional responses in the moment, habits are about sustained routines — must be made explicit to teachers. **Recommendation:** Define the boundary clearly and where they overlap (e.g. a breathing technique used both in-the-moment and as a daily practice), name the overlap explicitly.
+- **Reflective Thinking** and the meta-reflective dimension of **Self-Awareness & Regulation** at Band D overlap. **Recommendation:** At Band D, design assessment tasks that integrate both competencies — a reflective portfolio on personal regulation development would serve both.
+
+**Difficult transitions:**
+- **Band B → C** is the most significant transition: from experiential, practice-based learning to science-informed, analytically demanding content. Three new hierarchical concepts, a step up in horizontal sophistication, and informed rather than practised dispositional expectations. **Recommendation:** Begin Band C with a bridging unit connecting Band B experiential knowledge to new scientific content — "You already know deep breathing calms you down. Now we're going to learn WHY — and that understanding will help you choose the right technique for different situations."
+- **Band C → D** for horizontal elements: the shift to meta-level thinking will not happen spontaneously for most students. **Recommendation:** Explicit modelling of meta-reflective thinking at the start of Band D.
+
+**Compound competencies:**
+- **Health Literacy & Habits** is compound across knowledge types: hierarchical knowledge (nutrition, sleep, exercise science), horizontal thinking (evaluating health claims), and dispositional practice (maintaining routines). The same competency is being sequenced by three different logics simultaneously. **Recommendation:** Consider splitting into Health Knowledge (hierarchical — assessed by structured responses) and Wellbeing Practice (dispositional — assessed through self-reflection and developmental conversation).
+
+**Priority actions (in order of impact):**
+1. **Ensure autonomic nervous system content is taught at the START of Band C** before regulation expectations assume students understand why techniques work. This is the highest-impact sequencing decision.
+2. **Design a cross-competency bridging unit at the start of Band C** connecting experiential Band B learning to scientific Band C content.
+3. **Add scientific reasoning about evidence** to the Wellbeing Science & Literacy strand at Band D, or verify it is covered in the science curriculum.
+4. **Make Agency and Care for Others explicitly named and tracked** — unnamed intended outcomes are not assessed and tend to be neglected.
+5. **Define the boundary between Self-Awareness & Regulation and Health Literacy & Habits** explicitly for teachers, so both competencies are taught with clear scope.
+
+---
+
+## Known Limitations
+
+1. **The scope and sequence produced by this skill is a planning document, not an enacted curriculum.** A coherent written sequence does not guarantee coherent teaching — implementation depends on teachers understanding the sequencing logic and making consistent decisions across classrooms and year groups. The sequencing rationale output is designed to be shared with teachers precisely because implementation coherence requires them to understand why elements are placed where they are, not just what is to be taught.
+
+2. **Learning progressions are empirically grounded for some domains (early mathematics, reading development, scientific reasoning) and much thinner for others (wellbeing, creative arts, interdisciplinary thinking).** Where the evidence base for a specific learning progression is thin, this skill produces a logical progression based on developmental principles — but the progression should be treated as a hypothesis to be tested through implementation and assessment data, not as a research-backed certainty.
+
+3. **This skill produces a recommended sequence; it cannot enforce it.** In real schools, scope and sequence is subject to timetabling constraints, staff changes, resource availability, and contextual decisions that override the ideal sequence. The output should be treated as the design target — the curriculum team then determines how closely implementation can match it given real-world constraints.
+
+4. **The three-type knowledge framework used for sequencing is a simplification.** Real knowledge elements often sit on boundaries between types, and the sequencing logic for boundary cases requires professional judgment that this skill can prompt but not replace. Where elements are classified as primarily one type for sequencing purposes, the classification should be made explicit so teachers understand the reasoning.
+
+5. **Scope and sequence design is never finished.** As students move through the programme, assessment data will reveal where the sequence is working and where it is producing gaps or struggles. The scope and sequence designer produces the best available plan given current knowledge — it should be reviewed and revised at least annually using real student outcome data. The gap-analysis-from-student-work skill is the natural tool for feeding that data back into sequence revision.
+
+6. **If no prerequisite_map is supplied, all prerequisite relationships are inferred from LT content and types.** Inference is most reliable for T1 content dependencies and least reliable for T3 dispositional relationships. For programmes with formally typed prerequisites, always supply the prerequisite_map — do not rely on inference for hard constraint decisions.
+
+7. **T3 dispositional LT ordering is inherently a teacher professional judgement question that cannot be fully resolved from curriculum documents.** The skill provides principles and flags decisions for review. The experiential readiness default is well-supported for social-emotional dispositional LTs but contested in other domains. Use sequencing_principles to override.
+
+8. **Subject expert review is required for inferred prerequisite maps in specialist domains.** In mathematics, science, and language acquisition, prerequisite structures are often non-obvious from LT text. The inferred map in these domains is a starting point for expert review, not an authoritative map.
+
+9. **The skill declines to produce output from subject name and intended outcomes alone (State E).** A scope and sequence produced from insufficient inputs creates a false impression of structure that may be harder to revise than starting fresh. Run Learning Target Authoring Guide and KUD Chart Author first.


### PR DESCRIPTION
## 补齐教师端「教案与教学设计」

这是教师端此前缺失的核心一环。5 个 Skill 均来自循证教学技能库 [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills)(Agent Skills v2 规范、带真实学术引用、主动剔除伪科学如"学习风格")。

| Skill | 一句话 |
|---|---|
| backwards-design-unit-planner | 逆向设计(UbD):从学习成果倒推评估与活动,产出完整单元教学计划 |
| scope-and-sequence-designer | 课程范围与进度:跨年级/学期纵向进阶 + 横向衔接 + 连贯性检查 |
| explicit-instruction-sequence-builder | 显性教学课时序列(I Do/We Do/You Do),可直接上课的课时教案 |
| differentiation-adapter | 同一任务按学困/超常/多动等差异化适配,保持学习目标不变 |
| formative-assessment-technique-selector | 按教学时刻挑随堂检测/形成性评估技术,含实施与应答解读 |

### 对齐规范
- `category: 教学辅导`;`description` 改写为中文(含触发词),便于中文学习助手触发
- 保留原始 v2 frontmatter(evidence_sources / input_schema / chains_well_with)与正文
- `类型=收集`,引用真实上游作者 GarethManning(非二手聚合)
- README 新增分组「🧑‍🏫 教育 · 教案与教学设计」

🤖 Generated with [Claude Code](https://claude.com/claude-code)