### PR TITLE
feat(skill-library): 新增 Anthropic 官方 K-12 教师技能 2 个(备课 / 分层教学)

### DIFF
--- a/skill-library/README.md
+++ b/skill-library/README.md
@@ -55,6 +55,8 @@ Inno Agent Skill 集合整理 —— 每个 Skill 是独立目录，可直接下
 
 | Skill | 类型 | 通过验证 | 一句话 | 引用 |
 |---|---|---|---|---|
+| [k12-lesson-planning](./k12-lesson-planning/) | 收集 |  | K-12 从零备课：教案＋学生用材料＋课堂观察表，分学科（数学/ELA/科学/社会），输出可编辑 Word | [anthropics/k12-teacher-skills](https://github.com/anthropics/k12-teacher-skills/tree/main/plugin/skills/k12-lesson-planning) |
+| [k12-lesson-differentiation](./k12-lesson-differentiation/) | 收集 |  | 把已有 K-12 课按学生水平分层：1 份教师分层方案＋3 份学生分层材料，全为可编辑 Word | [anthropics/k12-teacher-skills](https://github.com/anthropics/k12-teacher-skills/tree/main/plugin/skills/k12-lesson-differentiation) |
 | [backwards-design-unit-planner](./backwards-design-unit-planner/) | 收集 |  | 逆向设计（UbD）：从学习成果倒推评估证据与学习活动，产出完整单元教学计划 | [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/backwards-design-unit-planner) |
 | [scope-and-sequence-designer](./scope-and-sequence-designer/) | 收集 |  | 课程范围与进度：跨年级/学期的纵向进阶与横向衔接，带先修依赖与连贯性检查 | [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/scope-and-sequence-designer) |
 | [explicit-instruction-sequence-builder](./explicit-instruction-sequence-builder/) | 收集 |  | 显性教学课时序列（I Do/We Do/You Do），含理解检查点与时间分配的可上课教案 | [GarethManning/education-agent-skills](https://github.com/GarethManning/education-agent-skills/tree/main/skills/explicit-instruction/explicit-instruction-sequence-builder) |

--- a/skill-library/k12-lesson-differentiation/LICENSE
+++ b/skill-library/k12-lesson-differentiation/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skill-library/k12-lesson-differentiation/SKILL.md
+++ b/skill-library/k12-lesson-differentiation/SKILL.md
@@ -1,0 +1,504 @@
+---
+name: k12-lesson-differentiation
+category: 教学辅导
+description: >-
+  把一节已有的 K-12 课(数学、语文/英语 ELA、科学、社会与历史)按学生水平做分层适配:低于年级水平 / 达到年级水平 / 高于年级水平。在向老师追问课程、层级或学生水平之前就应加载本技能。一次性产出 1 份教师用分层方案 + 3 份学生可直接用的分层材料,全部为可编辑 Word 文档;由同一份材料源 JSON 经内置脚本渲染,共享内容只写一次,保证各层不跑偏。连接 Learning Commons 知识图谱时会自动使用,不连也能用。本技能只改造老师带来或指名的已有课程;从零建新课请用 k12-lesson-planning。不适用于批改、量规、评估反馈或测验。触发词:分层教学, 差异化教学, 因材施教, 分层材料, 学生水平不一样, 给这节课做分层, 分层作业, 搭支架, 照顾不同层次; differentiate, tier, scaffold a lesson.
+license: Complete terms in LICENSE
+---
+
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# K-12 Lesson Differentiation
+
+Adapts an existing K-12 lesson for below / at / above grade-level proficiency using
+research-based differentiation principles (Tomlinson framework + subject-specific access
+design). Works with or without the Learning Commons Knowledge Graph connector.
+
+"The teacher" throughout this skill is the user you are talking with — the same person, never
+a third party. "Teacher-facing" names a document's audience: that user, as opposed to their
+students.
+
+---
+
+## Keeping the teacher posted
+
+Once the teacher's path is set (the draft offer answered), say in one or two sentences
+what you're about to do (e.g. *"I'll read your lesson, ground it in the standard and
+curriculum materials, design the three tiers, and build the worksheets."*).
+
+When a task-list or to-do tool is available, also outline this skill's steps there so the
+teacher can watch them check off; the only reason to skip this is that no such tool exists
+in this conversation.
+
+Teacher language only — name what the teacher is getting, never tool names, file names,
+"JSON", or "rendering".
+
+---
+
+## Step 0 — Route (silent, before anything else)
+
+1. **Subject.** Detect math / ELA / science / social studies from the source lesson or the
+   request, then read the matching reference file NOW:
+
+   - math → `references/math.md`
+   - ELA → `references/ela.md`
+   - science → `references/science.md`
+   - social studies → `references/social_studies.md`
+
+   **Loading the matching reference file is mandatory.** It carries the pedagogy for Steps 1
+   and 3 (source-lesson identification, curriculum detection, the eight differentiation rules
+   R1–R8, the document content templates, and the differentiation.json mapping).
+   Differentiating without first reading the subject reference is a critical failure on par
+   with skipping the Knowledge Graph.
+2. **Curriculum.** The subject file's "Identify the source lesson" section includes curriculum
+   detection (Illustrative Mathematics / OpenSciEd). When confirmed, use that
+   curriculum's discourse language and structures in the teacher plan, per the subject file.
+
+   **Curriculum is confirmed when:** the teacher explicitly names it, OR the uploaded source
+   lesson references it (a lesson from an IM unit or an OpenSciEd unit
+   counts — the upload is implicit confirmation).
+
+   **If curriculum is NOT confirmed** (not detectable from upload or link, no explicit mention):
+   never name a specific module, unit number, lesson number, or proprietary routine name anywhere
+   in the output OR in any chat message — even if you recognize the routine from training.
+   Describe the instructional move in your own generic terms ("a compare-strategies
+   discussion", not the routine's trademarked name). This is a hard rule; violating it fails P9,
+   and chat messages count. See **Copyright guardrail** (after Step 3) for the companion rule on
+   verbatim reproduction.
+3. **Connector.** Check whether the Learning Commons Knowledge Graph tools (e.g.
+   `find_standard_statement`) are available in this conversation. This decides which path
+   Step 2 takes. The skill is fully functional without the connector.
+
+4. **State.** Before any KG call, scan the conversation and any uploaded source lesson for
+state signals and store as `state`:
+   - Teacher says "I teach in [state]," "I'm in [state]," or "We're in [state]"
+   - Standard codes in the prompt or source lesson follow a state-specific format:
+     TEKS 1xx.x.x → Texas; SOL → Virginia; OAS/PASS → Oklahoma; MA → Massachusetts;
+     CA/HSS or CA/CCSS → California; other state-prefixed codes → check state
+   - Source lesson URL includes a state agency domain (tea.texas.gov, etc.)
+
+   If state found: store `state = [state name]`. Pass as `jurisdiction="<state>"` in every
+   `find_standard_statement` call in Step 2. Use state framework codes (not national proxies)
+   in all output.
+
+   If state not found:
+   - for science, math, or ELA, proceed with national defaults (CCSS for math/ELA, NGSS for science). Add this single footer line to the teacher plan:
+   *"Standards applied using [CCSS / NGSS] — if you're in Texas, Virginia,
+   Oklahoma, or another state with a distinct framework, share your state and I'll re-anchor."*
+   - for social studies, ask the teacher what state they teach in before proceeding.
+
+
+
+---
+
+## Step 1 — Identify the source lesson
+
+Follow the subject file's source-lesson section: Scenario A (lesson exists earlier in this
+conversation — use it directly, do not re-ask), Scenario B (teacher uploads a lesson — read it
+first; if unreadable, say so and ask to re-share, never silently fabricate), Scenario B2
+(teacher links a lesson by URL — fetch and read it; if the fetch fails,
+ask them to paste or upload; fetching completes Step 1 only — the KG calls in Step 2 are still
+mandatory), Scenario B3 (math or science only — teacher names a curriculum lesson by position or title —
+e.g. "IM Grade 6, Unit 2, Lesson 3" or "the OpenSciEd lesson on ecosystem dynamics" — Step 1
+is complete; proceed directly to Step 2 where `find_curriculum_lessons` will retrieve the
+lesson materials; do NOT ask the teacher to upload or link the lesson), or Scenario C (no source lesson present —
+ask the subject file's clarifying question before proceeding).
+
+A fetched link lands in the conversation whole, so a document bigger than one lesson
+(a module or unit teacher edition) will not fit. When a link points at one, work from
+what the request itself tells you about the lesson and confirm the specifics with the
+teacher — topic, grade, and standard carry enough to build from, the same way Scenario C
+proceeds after its clarify.
+
+**Learner needs check (silent, runs every time):** Before generating, scan the conversation
+for any mention of ELL levels, WIDA levels, IEP goal areas, 504 accommodations, or specific
+student needs. If found, incorporate into the tier design — especially the Below tier.
+Say "home language," not a specific language, unless the teacher names one.
+
+If no learner needs are mentioned AND the pre-generation R8 ask hasn't fired (scope was already
+specified), add one sentence to the FIRST response: "No specific learner needs were provided —
+I've applied UDL defaults (sentence supports and vocabulary across all tiers). Share any ELL
+levels, IEP goals, or specific student data and I'll adjust."
+
+This check must run even when scope is specified. Learner variability information should be
+captured before generation, not after.
+
+
+---
+
+## Step 2 — Ground in standards
+
+**If the LC Knowledge Graph is connected:** follow the subject's section in
+`references/learning-commons-kg.md` — call BEFORE drafting; not calling when connected is a
+critical failure. This applies no matter how the source lesson was obtained — uploaded, pasted,
+or fetched from a URL. Retrieving the lesson never satisfies this step.
+
+**If not connected:** proceed from best knowledge and add this footer to the teacher plan:
+*"Generated without the Learning Commons KG. Standard text, prerequisite grounding, and
+misconceptions reflect general best practice."* Do not invent KG citations.
+
+---
+
+## Step 3 — The differentiation rules
+
+Apply **all eight rules (R1–R8)** from the subject file to every differentiated lesson. The
+rules are subject-specific (scaffold types, tier entry points, extension quality tests differ
+by subject) but their structure is shared: output structure (R1), standard scope preservation
+(R2), tier entry points (R3), below-level scaffolds with a density cap (R4), required
+pedagogical infrastructure (R5), invisible modifications (R6), within-level progressive
+scaffolding (R7), and scope/defaults (R8).
+
+---
+
+## Copyright guardrail
+
+Always write original content. When the source lesson draws from a named curriculum (IM,
+OpenSciEd), use it to understand structure, scope, task context, and standards
+alignment only — never reproduce student-facing text, activity narratives, investigation
+prompts, comprehension questions, or problem contexts verbatim from curriculum materials.
+Each subject reference file carries a **Copyright** line with subject-specific details.
+
+If curriculum is NOT confirmed (see Step 0.2 detection rules), never name a specific
+curriculum, module, unit number, lesson number, or proprietary routine name anywhere in the
+output or in any chat message — even if recognizable from training. The source lesson and
+KG data inform the design without being cited. See Step 0.2 for the full rule (P9).
+
+---
+
+## Step 4 — The draft offer
+
+The teacher gets the choice of a fast draft before the build. The offer is
+asked the same way as the clarify questions — through the structured question tool when
+one is available, in chat otherwise — as its own separate question, batched with whatever
+you ask before Step 2 (state, source lesson, learner needs) and asked on its own when
+nothing else needs asking.
+
+- Question: *Should I go ahead and build the full classroom-ready set (teacher plan + three tier documents, as
+  editable Word docs), or do you want to see a quick draft first?*
+- Options: **Go ahead and build it** · **Quick draft first** — what changes for each
+  tier, right here in chat
+
+**The full set is the default.** Declining, not answering, or anything like "proceed with
+your defaults" runs Steps 2–3 and goes straight to Step 5; the draft happens only on a clear yes.
+
+**The draft (on a yes) is built on Steps 2–3, never instead of them.** Run Step 2 in
+full — every KG call, exactly as written — and Step 3 before sketching anything. A draft
+sketched without the Step 2 grounding is a critical failure, the same failure as skipping
+the KG on the full build. Then present the design in chat — the draft is chat text only;
+rendering happens at Step 5 once the teacher approves. Show:
+
+- one line reading back the source lesson, standard, and grade;
+- for each tier (below / at / above), 2–3 bullets on what changes and why;
+- the student work at a glance — each tier's actual tasks, enough for the teacher to
+  skim and judge coverage;
+- one line on what every tier shares — the essential question or core task — and the
+  regroup rule
+
+The draft borrows its names from the documents it previews — phases, tasks, tiers,
+and sections are called what the plan will call them.
+
+Afterwards, ask what's next — a structured question, two options:
+
+- **Make changes** — adjust any tier or the shared task
+- **Create the materials** — teacher plan and the three tier documents, as editable Word
+  documents
+
+Apply change requests to the draft in chat and re-present it — changes are quick at this
+stage. Step 5 runs in the turn the teacher gives the go-ahead ("Create the materials",
+"proceed with your defaults", or similar).
+
+---
+
+## Step 5 — Output (one turn)
+
+Runs immediately when the teacher chose the full set, or in the turn the draft is
+approved.
+
+Four artifacts — **1 teacher-facing plan + 3 student tier documents (below / at / above)** —
+are all rendered by a bundled script from **one `differentiation.json` (the material source)**. Anything that
+appears in more than one artifact (standard, problem/task set, exit ticket, vocabulary,
+sentence supports, misconceptions) lives ONCE in the JSON's `shared` block and is pulled into
+each document with `{"type": "from_shared", "key": …}` blocks, so the teacher plan and the
+tier documents cannot drift apart — and R6 (same context, same core tasks across tiers) is
+enforced structurally.
+
+Never write layout code, never re-type content into another format, and never edit a generated
+document directly — every change goes into `differentiation.json` and is re-rendered
+(re-rendering is instant).
+
+**Plain language with the teacher.** The machinery above is invisible to the teacher: never
+mention JSON, HTML, schemas, scripts, rendering, file names (`differentiation.json`), or code
+in any teacher-facing message — and never link or name the `.html` files the render command
+also writes. Say *"Here's your differentiation plan — the three tier documents are on their
+way"*, not *"I've rendered differentiation.json"*. The only format word in your prose is
+"Word document". This applies to every
+turn: presenting artifacts, the satisfaction ask, revision summaries, and error messages (if
+generation fails, say the documents couldn't be created — not that a script or JSON failed).
+
+**Density rules — hard requirements for every document.** Teachers consistently flag dense
+walls of text. Structure beats prose:
+
+- A `paragraph` or `labeled` block is at most 3 sentences. Longer → split it, bullet it, or
+  table it.
+- Bullets are fragments — one idea each, ≤ ~15 words; never chain clauses with semicolons.
+- Parallel tier content (Below / At / Above doing the same phase differently) goes in ONE
+  `table` block — rows = phases or features, columns = tiers, ≤ ~25 words per cell — never
+  three back-to-back multi-sentence paragraphs.
+- An aside longer than one sentence (misconception watch-fors, confer prompts, deployment
+  guidance) becomes its own `callout` block, not a sentence buried in a paragraph.
+- Quote the standard verbatim exactly once (the target-standard callout, from `shared`).
+  Everywhere else — prerequisite grounding, forward connections — reference by code plus a
+  gist of ten words or fewer; never re-paste full standard text.
+- A section that runs past about half a page of continuous prose must be restructured
+  (table, bullets, or split into two sections) before rendering.
+
+**Pre-write cross-check — run ALL checks before calling the render script. Do not render until every item passes.**
+
+**O6 — Artifact alignment (both directions):**
+1. **Plan → tier documents.** List every task the plan says students do — tier problems/tasks,
+   exit ticket, the anchor activity, anything assigned to "early finishers." Each must have a
+   printed student-facing block on at least one tier document (the anchor activity on all
+   three, via `from_shared: anchor_activity`). A task that exists only as a plan description
+   fails.
+2. **Tier documents → plan.** For each tier document, list every printed task — each
+   problem/task, the extension and each of its printed sub-parts, anything printed on one tier
+   only, the exit ticket, "If you finish early," "Reflect." Each must appear in that tier's
+   **Worksheet tasks** line in the plan, with its scaffold named (e.g., "P1 (tape diagram +
+   sentence support)" not just "P1"). A printed task the plan never names fails — a named
+   scaffold the worksheet does not print fails — and so does a plan line naming a task or
+   organizer no tier document prints.
+
+Shared content is guaranteed by `from_shared` blocks; the check targets document-specific
+blocks and plan prose. Also confirm the exact `shared.standard_code` string appears in each of
+the three tier documents' `eyebrow` (`"[Grade] [Subject] · [standard_code]"`) — the standard
+must be named on every tier, not only in the teacher plan. Fix mismatches before rendering.
+
+**Classroom-ready (every document):** the tiers run on what the teacher already holds.
+Every resource a worksheet or the plan names is a printed block in this package, equipment
+the classroom has, or a sourced resource with its access path stated — exact title and
+source, a link when you could confirm one. A visual a task depends on prints on the
+worksheet that uses it, or the task is rewritten to work from what does print. Anything
+harder to get than that stays out unless the teacher steered toward it.
+
+**P8 — Flexible grouping (confirm in teacher plan JSON):**
+- The `Flexible Grouping` section states the evidence or basis used to assign students to each
+  tier (e.g., a specific prior exit ticket, diagnostic score, or "Default profile applied — no
+  diagnostic data available"). A blank or generic statement fails.
+- The section includes an explicit statement that tier assignments are revisable based on
+  formative evidence from THIS lesson (not a standing ability track).
+
+**O4 — Rationale notes (confirm in teacher plan JSON):**
+- `Why this works (1)` and `Why this works (2)` sections are present and each name a specific
+  tier design choice with a stated reason. Generic statements ("scaffolds help learners") fail.
+  These sections are required and cannot be dropped to meet page caps — tighten other content
+  instead.
+
+### 5a. Write the complete `differentiation.json` (same turn)
+
+1. Write `differentiation.json`: top-level `theme`, the **`shared` block** (write this FIRST —
+   the identity fields, the standard verbatim, each tier task under its own key (`t1`, `t2`, …),
+   the exit ticket, and composed blocks for vocabulary, sentence supports, and misconceptions;
+   also `anchor_activity` (early-finisher task in student-facing second person — directions
+   only, no rationale) and `reflect_prompt` (the closing reflective question)), and a
+   `documents` array with 4 entries: `{"id": "teacher_plan", "audience": "teacher", …}` and
+   `{"id": "worksheet_group_a" / "worksheet_group_b" / "worksheet_group_c", "audience": "student", …}`.
+   Each document's `sections` follow the subject file's document content templates.
+
+   **Schema** — the complete field skeleton (`blocks` shows one of each type). This is
+   sufficient — **do not open, cat, head, or grep the renderer scripts**:
+
+   ```
+   theme: {primary: "#…"}
+   shared:
+     subject, grade, standard_code, standard_text        (required identity)
+     duration?
+     <any key you choose>: string
+                         | block | block[]
+                         | {teacher: …, student: … or null, stimulus?: block[]}
+     (only `standard` is special — it assembles standard_code+standard_text)
+   documents[]: {id: teacher_plan|worksheet_group_a|worksheet_group_b|worksheet_group_c,
+                 audience: teacher|student, eyebrow, title, meta,
+                 sections[]: {heading, blocks[]}}
+     block types:
+       {type: from_shared, key, label?}
+       {type: labeled, label, text} | {type: paragraph, text}
+       {type: callout, kind: special|student-task|teacher-note|student-note, label, text}
+       {type: h2, text} | {type: h3, text} | {type: list, label?, ordered?, items[]}
+       {type: checklist, label?, items[]} | {type: fill_in, label?, size: short|med|long}
+       {type: phase_header, name, minutes}   (science teacher plan; supported by all renderers)
+       {type: table, headers[]?, rows[[]], empty_row_height_pt?}
+       {type: fill_table, headers[], blank_rows: int, row_height_pt?}
+       {type: number_line, min, max, ticks?, marks[]?}
+       {type: source_card, title, author?, date?, origin?, excerpt}
+       {type: cards, items[{title, text}]} | {type: workspace, size: small|med|large, height_pt?}
+       {type: group, blocks[]} | {type: columns, left[], right[]} | {type: page_break}
+   ```
+
+   **`shared` is a content registry.** Register each tier task under its own key (`t1`,
+   `t2`, …), the exit ticket as `exit_ticket`, and any other content that appears on more
+   than one document, under keys you choose. A key's value can be a string, a composed
+   block (a vocabulary `table`, a misconceptions `table`, sentence-support text with its writing space), or a
+   faceted object `{teacher: …, student: …}` — on a **student** page only the `student`
+   facet renders; on the **teacher** page both render (the teacher facet as a teacher-note,
+   then the student facet as a "What students see" callout). Key names carry no special
+   rendering — compose vocabulary, misconceptions, and sort buckets as blocks yourself
+   (`references/example_differentiation.json` shows each pattern).
+
+   (`references/example_differentiation.json` is a filled-in worked example if
+   values-in-context would help, but reading it is not required.) Keep writing tight; no emoji in JSON content.
+   The density rules above are hard requirements for every text field.
+   **Which block when** — pick by what the content *is*, not how it should look:
+
+   | Block | Use it for |
+   |---|---|
+   | `callout` `kind: special` | The one anchoring fact per artifact — the target standard. Typically once. |
+   | `callout` `kind: student-task` | Any task students do: anchor task, exit ticket prompt, a tier task shown in the plan. |
+   | `callout` `kind: teacher-note` | An aside the teacher reads but does not say aloud: conferring moves, a watch-for. |
+   | `callout` `kind: student-note` | A reminder students read on their worksheet: a hint card, a key fact. (A sentence support students write from is plain text near its task, not a callout.) |
+   | `list` `ordered: true` | A numbered sequence — the problem set, procedure steps. Unordered otherwise. |
+   | `list` with `label` | A titled enumeration — several discrete items under one label. |
+   | `cards` | 2–4 parallel items of roughly equal length — tier summaries, sort buckets. Never for long or unbalanced items. |
+   | `table` (no `headers`) | Term/definition pairs, label/value reference rows. |
+   | `table` with `headers` | Real tabular data with column labels (per-tier scaffolds, misconceptions). |
+   | `number_line` | A drawn number line (`min`, `max`, `ticks`, optional `marks`). `ticks` omitted defaults to 10 evenly spaced segments; `ticks: 0` draws a bare line with only the `min`/`max` end labels and no tick marks, for students to partition themselves. |
+   | `workspace` | Student writing space; `size: small|med|large` or grade-banded default. |
+   Tabular content — data tables, "complete the table" tasks, row-and-column organizers — must
+   be a `{"type": "table", "headers": [...], "rows": [[...]]}` block (a row of empty strings
+   renders as ruled writing space). Never draw a table inside a `text` field: markdown pipe
+   rows, box-drawing characters, ASCII art, and symbol glyphs (■, □) print literally on the
+   page and fail print-safety. Never write bullet characters (•, -) inside a `text` string
+   — use a `bullets` block; a paragraph collapses line breaks and the bullets run together
+   into one line. Use `workspace` blocks for writing space — they render as
+   open whitespace sized by grade automatically (lower grades get much more room, and K–5
+   prose answers get ruled lines; math work space stays open for drawing). Set `height_pt`
+   only when a task needs more than the default: 130–150 for full written explanations and
+   exit tickets, 90–110 for short extension questions. Empty table cells are writing space
+   and get a grade-banded minimum height automatically — don't set `empty_row_height_pt`
+   below ~70pt for prose rows. This applies to
+   every prose field in all four documents.
+2. The three tier documents (in the same `documents` array) differ ONLY in their scaffolding
+   and extension blocks (R6).
+   **Every tier document pulls task text with `from_shared` blocks — never re-type, reword,
+   or split task text into a document's own blocks** (so the plan and all three tiers stay
+   verbatim-consistent — reworded tasks drift apart in revision). Each task has its own
+   `shared` key, pulled one at a time so scaffolds sit with their task:
+   `{"type": "from_shared", "key": "t1", "label": "1"}` renders Task 1 as a numbered item;
+   follow each task — and every other prompt students answer (the exit ticket, Reflect,
+   If you finish early, a tier-only extension) — with a `workspace` block.
+   The required order within the section is strict: for each task N — at most ONE
+   scaffold block for task N (merge multiple supports into one labeled block; never two
+   "Before Task N" blocks), then the task via its key. A scaffold must NEVER appear
+   after its target task, and nothing sits between a scaffold and its task.
+   That is how the R7 fade pattern is expressed — Task 1 gets a scaffold block, Task 2's is
+   lighter, later tasks have none. A tier-only task (the Above extension, an Above-only
+   sub-question) is its own headed block — never an edit to shared task text. Below-tier scaffolds follow R4; the Above-tier extension passes R7's quality
+   test. Asset framing rules (below) apply to every student-facing block.
+
+### 5b. Render all four Word documents — one command, same turn
+
+```bash
+bash scripts/render_all.sh differentiation.json "$OUTPUT_DIR"
+```
+
+This writes `$OUTPUT_DIR/teacher_plan.docx`, `$OUTPUT_DIR/worksheet_group_a.docx`,
+`$OUTPUT_DIR/worksheet_group_b.docx`, and `$OUTPUT_DIR/worksheet_group_c.docx` in one invocation,
+plus `.html` working files — no copy step needed; leave everything
+the script writes in place (later revision turns re-render from the working files). Then list
+`$OUTPUT_DIR` and confirm every document has both its `.docx` and `.html`; if either is
+missing or tiny, rerun the script. Present all four Word documents to the teacher together —
+attach the teacher plan last so it lands on top (chat surfaces stack newest-first). If the script errors, fix
+`differentiation.json` (it is almost always malformed JSON) and rerun. If file generation
+fails entirely, say so clearly — do not silently fall back to a chat-only delivery.
+
+### 5c. The close (every output turn)
+
+The chat message that delivers artifacts ends with three things, in order. Each must appear in
+the chat message itself — saying it only inside the printed plan does not count. When the
+message mentions the sheets, use their group names with the association noted once
+(Group A = below grade level, etc.).
+
+1. **Learner-variability statement (first output turn, when you didn't ask).** If you never
+   asked about specific learner needs in this conversation (the R8 question), state in chat
+   that UDL defaults were applied and invite specifics — e.g. *"I didn't have details on
+   specific learner needs, so I applied UDL defaults — sentence stems and a vocabulary
+   glossary on all three tier sheets. Tell me about any multilingual learners or students
+   with IEPs or 504 plans and I'll tailor further."* Skip this only when the teacher already
+   gave learner information (then reflect it instead: "the Below sheet builds in the sentence
+   frames for your newcomer ELLs").
+2. **Three lesson-specific next steps (first output turn).** Offer 3–4 iteration options in
+   chat, one short line each, specific to THIS lesson (e.g., a tiered ELD layer with
+   WIDA-banded sentence supports; IEP-goal-specific scaffolds for a named goal area; a fourth
+   intervention tier below the prerequisite; tightening scope to the exit ticket only). The
+   subject reference's FA follow-up prompt counts as one of them when it fits.
+3. **The satisfaction ask.** Ask whether the teacher is satisfied with **all four artifacts**
+   or wants changes. Do not skip the ask — on every output turn, including revisions.
+
+### 5d. Revisions — one edit, every artifact stays in sync
+
+Make **targeted edits to `differentiation.json`**, then re-render all four documents (instant).
+Rules that keep the artifacts consistent:
+
+- If the change touches shared content (context, numbers, tasks, exit ticket, vocabulary,
+  sentence supports, misconceptions), edit it **in `shared`** — it propagates to the teacher
+  plan and every tier document automatically.
+- **Consistency sweep after any context/number/task change:** after editing `shared`, re-read
+  every prose block in all four documents' `sections` and update every sentence that still
+  mentions the old context, names, or numbers. No artifact may reference the replaced content
+  anywhere — stale prose is the most common consistency failure.
+- A change aimed at one tier (e.g. "more scaffolding for below", "harder extension") goes in
+  that tier document's blocks — never by forking shared content. Scaffold changes must keep
+  the subject file's R4 rules and R7 fade pattern.
+- Styling: top-level `theme` applies to all four documents; per-document `theme` overrides
+  stay available.
+
+### 5e. Fallback — bespoke generation code (exception path only)
+
+Only if the user explicitly asks for an artifact or layout the bundled renderer cannot express
+(a different document type, landscape poster, slide deck, etc.): write generation code from
+scratch for that artifact. Source its content from the same `differentiation.json` (especially
+`shared`) so it stays consistent with the other artifacts. Tell the user this path is slower.
+
+### Student-facing language — ALL tier documents
+
+Student pages never use instructional-design terminology. Those are teacher words; on a
+worksheet they read as labels about the student, not for the student.
+
+- ❌ "CER" — write the organizer labels out: *Claim / Evidence / Reasoning*. ("Write a CER"
+  becomes "Explain your claim with evidence and reasoning".)
+- ❌ "sensemaking check", "formative check", "misconception", "scaffold", "tier",
+  "differentiation", "anchor task" — use student words: *"Check your thinking"*, *"Try this
+  together"*, *"If you finish early"*.
+- On a student document the tier is named **Group A** (below), **Group B** (at), or
+  **Group C** (above): the `title` carries the group letter per the subject template; the
+  `eyebrow` stays `"[Grade] [Subject] · [standard_code]"` with no level wording. Grade-level
+  labels are teacher words — the teacher plan's tier labels ("Below (Group A)" etc.) carry
+  the association.
+- Scaffold prompts get a SHORT student-friendly `h3` on its own line (e.g.
+  *"Observe the data first"*, *"Check your thinking"*), then the prompt as a normal
+  paragraph below it — never a long bold inline label like
+  "**Before Task 2 — sensemaking check:** Complete this sentence…". The subheading names
+  what the student does, not the pedagogy behind it.
+
+### Asset framing — below-tier documents
+
+Student-facing language must not signal reduced expectations. Scaffolds appear as natural task
+design, not announced supports.
+
+- ❌ "Task 1 (Scaffolded) / Task 2 (Guided) / Task 3 (Independent)" — a student who sees these labels knows they are on the easier version.
+- ❌ "Use this if you need it" / "Here is a sentence starter" — names the support as a crutch.
+- ❌ Any header, label, or aside that distinguishes scaffolded tasks from unscaffolded ones.
+- ✓ The organizer, annotation frame, or sentence support simply appears as part of the task layout.
+- ✓ Tasks are numbered without scaffold-level labels.
+- ✓ Sentence supports at the top of the document are introduced universally: "You can use these sentence supports:" — not "Use these if you get stuck."
+
+---
+
+## Step 6 — Complete
+
+The skill is complete when the teacher has confirmed they are satisfied with all four Word
+documents (5c). The closing message pairs the FA follow-up prompt from the subject
+reference's R8 section with the lesson-specific next-step options from 5c.

--- a/skill-library/k12-lesson-differentiation/references/NOTICE
+++ b/skill-library/k12-lesson-differentiation/references/NOTICE
@@ -1,0 +1,3 @@
+© 2010 National Governors Association Center for Best Practices and Council of Chief State School Officers. All rights reserved.
+
+The Common Core State Standards included in these reference files are used under the public license available at: https://www.thecorestandards.org/public-license/

--- a/skill-library/k12-lesson-differentiation/references/ela.md
+++ b/skill-library/k12-lesson-differentiation/references/ela.md
@@ -1,0 +1,380 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# ELA — differentiation pedagogy
+
+Loaded by `k12-lesson-differentiation` when the subject is **ela**.
+
+## Identify the source lesson and curriculum
+
+Detect which scenario applies:
+
+**Scenario A — Source lesson exists in the prior conversation**
+If a lesson was produced or discussed earlier in this conversation, use it directly. Do NOT re-ask the teacher to share it.
+
+**Scenario B — Teacher uploads a source lesson**
+Read the file first. Confirm: grade level, ELA strand (reading, writing, or combined), standard, learning objective, and lesson structure. Also identify the text(s) used if present. If the file is unreadable on first attempt, surface the error clearly and ask the teacher to re-share. Do NOT silently fabricate a lesson.
+
+**Scenario B2 — Teacher links a source lesson by URL**
+Fetch the URL and read its content first. Then confirm grade level, ELA strand, standard, learning objective, lesson structure, and text(s) used exactly as in Scenario B. If the fetch fails or returns unusable content, surface the error clearly and ask the teacher to paste the lesson text or upload the file. Do NOT silently fabricate a lesson.
+
+**Fetching the lesson completes Step 1 only — it does NOT replace standards grounding.** Continue to Step 2 — Ground in standards. Skipping Step 2 after a URL fetch is the same critical failure as skipping it for an uploaded lesson.
+
+**Scenario C — No source lesson present**
+Ask before proceeding:
+> "Happy to differentiate. Do you have a specific lesson in mind? You can paste it, share a file, or tell me the grade + strand (reading, writing, or both) + standard and I'll work from that."
+
+---
+
+## Standards grounding
+
+Follow **Step 2 — Ground in standards** in SKILL.md: if the Learning Commons Knowledge Graph
+is connected, use the ELA section of `references/learning-commons-kg.md`; if not,
+proceed from best knowledge and add the disclaimer footer to the teacher plan.
+
+**State-aware standard resolution:** When state is known from Step 0, use state ELA framework
+codes in all output. Pass jurisdiction in the KG call per learning-commons-kg.md.
+
+
+## The differentiation rules
+
+Apply all eight rules to every differentiated lesson.
+
+### R1 — Output structure
+
+**1 cohesive teacher-facing differentiation plan + 3 pure student-ready materials. NEVER 3 hybrid per-level lesson plans.**
+
+The hybrid pattern — 3 per-level documents each mixing teacher notes and student tasks — is a specific failure mode. The teacher plan covers all levels in one document; the student materials are student-only, with no teacher notes, look-fors, or rationale.
+
+### R2 — Standard and strand scope preservation
+
+**Every tier addresses the original standard. Every learning component stays in play across all tiers.**
+
+ELA lessons commonly interweave multiple literacy strands — reading comprehension, vocabulary, and writing — within a single lesson. Differentiation must address each strand present. Do not drop a strand for below-level students; scaffold it instead.
+
+The standard's most demanding element (e.g., identifying an author's argument, writing a claim with evidence) is exactly what below-level students most need to encounter with supports — not the element to remove.
+
+**Engagement must be preserved at the Below tier.** Do not assign richer texts or prompts to At/Above and drill-like work to Below. All tiers work with the same text and same essential question — with different supports, not different tasks.
+
+### R3 — Text access: same text, different scaffolds
+
+**All three tiers work with the same grade-level text. Text complexity is not adjusted — access to the text is.**
+
+This is the foundational ELA differentiation principle. Handing below-level students an easier text closes off grade-level engagement rather than building toward it. Instead, scaffold how students access the grade-level text.
+
+The tiers map to a progression from supported access to independent analysis:
+
+| Tier | Cognitive entry point |
+|---|---|
+| Below | Supported access → scaffolded production. Student works with the grade-level text using chunked reading, pre-taught vocabulary, annotation guides, and sentence supports to reach the task. |
+| At | Standard engagement. Student reads the grade-level text and completes the task as designed. |
+| Above | Independent analysis / synthesis. Student reads the grade-level text and moves beyond retrieval to author's craft, evaluation, cross-text connection, or generative production. |
+
+When the KG names a prerequisite standard, identify what reading or writing skill students already have from that standard — and build the below-level scaffold to bridge from that prior skill to the grade-level task.
+
+**For writing lessons:** keep the same prompt and writing purpose across tiers. What varies is structural support (frames, organizers, models). Do not reduce the writing purpose (e.g., do not convert an argument to a summary for below-level students).
+
+### R3.5 — Foundational literacy prerequisite check (K–5 only)
+
+**For lessons in grades K–5, determine whether the below-level student's likely barrier is a decoding/fluency gap or a comprehension/vocabulary gap before selecting scaffolds. These require different responses.**
+
+Decoding and reading fluency are hard prerequisites for comprehension work — not gaps that comprehension scaffolds can compensate for. A student who cannot decode the text fluently cannot be scaffolded into comprehension of it. This is the most common failure mode in K–5 below-level differentiation: applying comprehension scaffolds to a student whose root problem is foundational.
+
+**By grade band:**
+
+- **K–2:** Phonics or decoding gaps are possible, especially if the student is receiving Tier 2 support. Comprehension scaffolds are appropriate as concurrent supports but treat them as such — not as root-cause interventions.
+- **3–5:** Default below-level profile is a fluency ceiling — adequate decoding accuracy, low automaticity, which taxes working memory and degrades comprehension. Prioritize fluency-supporting structures (read-aloud permission, partner reading, echo reading) alongside comprehension scaffolds. This is the highest-risk grade band for misidentification: a student who appears to have a comprehension problem may actually have a fluency gap.
+
+**If the primary barrier appears to be decoding or fluency, add a flag to the teacher plan under BELOW TIER. For example:**
+
+> *"⚠ Foundational literacy note: If students cannot read this text aloud fluently, comprehension scaffolds will not close the gap — the prerequisite need is decoding/fluency intervention delivered separately. Read-aloud is an appropriate access bridge while that support is in place, not a substitute for it."*
+
+Do not include this flag for grades 6–12 unless there is a specific signal of a late-identified reading disability. At those grades, below-level comprehension difficulty is more likely caused by vocabulary gaps, thin background knowledge, or weak inference skills.
+
+### R4 — Below-level scaffolds
+
+**Scaffolds support thinking without revealing answers. Use sentence supports, graphic organizers, annotation cues, and vocabulary supports. NEVER answer-revealing hints. NEVER simplified content substitutes.**
+
+Failure modes to avoid:
+
+- ❌ Substituting an easier text, passage, or writing prompt for below-level students. This removes grade-level engagement, not a scaffold.
+- ❌ Reducing writing purpose (e.g., changing argument to summary, or multi-paragraph to single sentence) when the standard requires the original form.
+- ❌ Pre-filled graphic organizers that leave only a blank for the final answer.
+- ❌ Telling students what the text is about before they read (comprehension-revealing prereading).
+- ❌ Sentence starters that answer the task ("The author argues that slavery was wrong because…") rather than structuring the student's own thinking ("The author argues that ______ because ______").
+
+Acceptable scaffolds:
+
+- ✓ Chunked reading with guided annotation cues: "As you read this paragraph, mark: the main idea (circle), one piece of evidence (underline), one word you don't know (?)"
+- ✓ Vocabulary support: 3–5 pre-taught key terms, defined in student-friendly language, available during reading and writing.
+- ✓ Sentence supports that structure thinking without completing it: "The author uses ______ to show ______." / "My claim is ______. One reason is ______."
+- ✓ Graphic organizers matched to the literacy task (see table below).
+- ✓ Read-aloud or partner reading permission (teacher-side, not embedded in worksheet) — appropriate as an access bridge for students with decoding gaps who are receiving phonics intervention separately. Not a substitute for that intervention. See R3.5.
+- ✓ Reduced number of text evidence examples required — while preserving the task type (e.g., find 1 example instead of 3, not switch to a different task type).
+
+#### Literacy task → primary scaffold
+
+Select the primary scaffold based on the literacy task, not the grade level:
+
+| Literacy task | Primary scaffold |
+|---|---|
+| Reading comprehension (narrative) | Story map: character / problem / event sequence / resolution |
+| Reading comprehension (informational) | Main idea + evidence organizer |
+| Argumentative / opinion writing | Claim–reason–evidence frame |
+| Narrative writing | Story spine or structured story map |
+| Informational / explanatory writing | Web organizer → paragraph frame |
+| Text analysis (author's craft, structure) | Annotation guide + "The author does ______ to ______" frame |
+| Compare/contrast (texts or characters) | T-chart or Venn with labeled categories |
+| Vocabulary in context | Word map: definition / example / non-example / sentence |
+
+Use this table to pick the **primary scaffold** before applying the density cap. If the lesson spans multiple task types, pick the scaffold for the task where below-level students most need support.
+
+The test: does the scaffold leave the intellectual work to the student, or does it perform the work for the student? If the latter, it is not a scaffold.
+
+#### Scaffold density cap
+
+**Cap embedded scaffolds at 1–2 per task.** Over-scaffolding shifts cognitive load to navigating supports rather than engaging with text or writing — equally harmful as under-scaffolding.
+
+| Type | Counts toward cap? |
+|---|:-:|
+| Embedded — printed on every task (organizer, sentence support, annotation cue) | YES |
+| Header-level features — vocabulary box, sentence supports at top of page | NO |
+| Teacher-side supports — read-aloud permission, conferring prompts, manipulatives | NO |
+
+**Pick a primary scaffold first.** Only add a second if it contributes a genuinely different mode (e.g., visual organizer + linguistic frame). If the second scaffold asks the student to do the same mental work as the primary, drop it.
+
+### R5 — Required pedagogical infrastructure
+
+**Every differentiated lesson must include all four:**
+
+| Section | What it is | Where |
+|---|---|---|
+| **Formative check** | Concrete mid-lesson or end-of-lesson prompt to gauge readiness — a tiered exit ticket counts. Not "monitor students." | Teacher plan + per-level student materials |
+| **Anchor activity** | Standard-aligned task for early finishers. Not busywork. Should connect to the ELA strand of the lesson (e.g., independent reading, writer's notebook extension). Written student-facing in `shared.anchor_activity` and printed on every student material — an anchor activity that exists only as a plan description is a failure. | Teacher plan + all three student materials |
+| **Flexible-grouping language** | Tier assignments tied to THIS lesson's evidence, explicitly revisable based on formative check results. Not static reading-level tracks. | Teacher plan |
+| **Per-level misconception / common error notes** | Common errors specific to each tier + teacher prompt + signal for pulling a small group. For reading: comprehension errors; for writing: craft or structure errors. | Teacher plan |
+
+In addition: **each student material ends with one open-ended or reflective prompt, present on all three tiers** — e.g., "What do you think the author's main purpose was? Use evidence from the text." / "What was the hardest part of your writing? What would you change?" This is not optional for any tier. Store it as `shared.reflect_prompt` and name it in each tier's **Worksheet tasks** line in the teacher plan — a printed task the plan never mentions is a failure.
+
+### R6 — Invisible modifications
+
+**Same text / same prompt / same core task across tiers where pedagogically possible. Only the supports differ.**
+
+What can differ: scaffolds embedded in the student materials; optional teacher-provided supports during conferring; the extension or reflection prompt depth.
+
+What should NOT differ: the text students read; the writing purpose or prompt; the structural challenge the standard targets; the topic or context.
+
+**Do not announce scaffold removals to students.** If a scaffold appears in Task 1 but not Task 3, its absence is silent — no label, aside, or comment (e.g., no "(No organizer this time)" or "Try it without the frame"). The scaffold simply does not appear; students encounter the task on its own terms.
+
+For writing: use the same prompt across all tiers by default. The number of required examples or the structural support may vary, but the task must not.
+
+For reading: do not create a "below-level version" of the text by simplifying sentences or reducing length. If the text is truly inaccessible (e.g., due to student language status), flag this in the teacher plan as a separate ELD consideration — not a standard differentiation tier.
+
+### R7 — Within-level progressive scaffolding
+
+**Each tier's student materials sequence tasks with progressive cognitive demand. Not uniform difficulty.**
+
+#### Below-level fade pattern
+
+| Task | Embedded scaffolds | Pattern |
+|---|:-:|---|
+| Task 1 | Up to 2 | Scaffolded |
+| Task 2 | Up to 1 | Guided |
+| Task 3+ | 0 embedded | Independent |
+| Exit ticket | 0–1 | Mastery check |
+
+The goal is a true fade (2 → 1 → 0), not uniform scaffold density across all tasks.
+
+#### Above-level extension quality test
+
+Every above-level extension must answer: **what new thinking does this require that the at-level student isn't already doing?** If you cannot name new thinking, the extension is cosmetic and should not ship.
+
+A real ELA extension requires at least one of:
+
+| Type | What it requires |
+|---|---|
+| Author's craft analysis | Move from "what does the text say" to "why did the author make this choice and what effect does it create." |
+| Perspective shift | Retell from another character's/narrator's point of view; argue the opposing claim; rewrite from a different rhetorical purpose. |
+| Cross-text synthesis | Connect to a second text, comparing argument, structure, author perspective, or theme. |
+| Structural insight | Generalization about genre, structure, or author strategy the at-level task treats as a single instance. |
+| Open generative task | Student produces something new: original piece in the author's style, counterargument, question for class discussion. |
+| Forward-standard preview | A real conceptual element from a higher-grade ELA standard — not just its vocabulary. |
+
+Reject if: more of the same, notation/vocabulary swap only, or restatement.
+
+If only one meaningful extension fits, include only that one.
+
+### R8 — Scope and defaults
+
+**If tier scope is not specified, ask ONE combined question before generating:**
+
+> "I'll differentiate this into below / at / above grade-level tiers — are those the right three? And any specific learner needs I should know about (ELL levels, IEP goals)? If not, I'll apply UDL defaults (sentence supports and vocabulary support across all tiers)."
+
+If scope is already specified, apply defaults silently and proceed.
+
+**Defaults applied silently when not specified:**
+- Tiers: below / at / above
+- UDL features: sentence supports and vocabulary glossary in **all three** student materials (not Below only — rubric O5)
+- Scope: full lesson (all phases + exit ticket)
+- Text: same grade-level text across all tiers (never substituted)
+
+**Default below-level profile absent formative data:**
+
+When no diagnostic data is available (no ORF scores, running records, phonics screener results, or exit ticket data), design for the most likely profile by grade band:
+
+- **K–2:** Phonics or decoding gaps are possible. Apply comprehension scaffolds as concurrent supports; include read-aloud permission as a teacher-side option; check whether a foundational literacy flag (R3.5) is warranted.
+- **3–5:** Default profile is a fluency ceiling — adequate decoding accuracy, low automaticity. Prioritize fluency-supporting structures (read-aloud permission, partner/echo reading) alongside comprehension scaffolds. Vocabulary pre-teaching is the second lever.
+- **6–8 and 9–12:** Default profile is vocabulary and background knowledge gaps. Academic Tier 2 and Tier 3 vocabulary is the most common bottleneck. Scaffold semantics and syntax first; decoding is likely sufficient for word recognition.
+
+Without formative data, assume the below-level student has gaps in the most proximal prerequisite for the lesson's primary literacy skill: for comprehension-focused lessons, vocabulary and fluency; for writing-focused lessons, organizational and sentence-level structure.
+
+**After generating the tiered plan, prompt the teacher for formative data:**
+
+> *"Do you have any reading data — ORF scores, running records, a phonics screener, or writing samples — that could help me target the right scaffolds? Even informal notes on where students got stuck would help."*
+
+Adjust the prompt by grade band:
+- **K–5:** Ask specifically for ORF scores, running records, or phonics screener results. This is the highest-stakes FA follow-up in ELA — whether the below-level student has a decoding gap vs. a comprehension gap changes the entire scaffold approach. Comprehension scaffolds built for a decoding-gap student waste instructional time.
+- **6–12:** Ask for exit ticket results or writing samples showing where inference or argument structure breaks down. FA data here usually confirms the default assumption (vocabulary/background knowledge) rather than inverting it.
+
+Do not treat the FA follow-up as optional for K–5. The default tiered plan is a best-guess; the gap between a decoding student and a comprehension student is too consequential to leave unconfirmed when data may be available.
+
+---
+
+### Document content — teacher plan (`id: teacher_plan`) — max 3 pages
+
+**Length budget: ~1,200 words rendered (the 3-page cap in practice).** Tighten the tier
+sections and overview before touching the closers (Flexible Grouping, Why this works, Next
+Steps) — the most common overrun is a Worksheet tasks line that restates student-material
+content instead of naming it.
+
+The outline below defines the content and order of the teacher plan document's `sections`:
+each `##` heading becomes one section, its body becomes that section's blocks (use
+`from_shared` blocks for the standard, misconceptions, and exit ticket; `labeled` blocks for
+the bold fields).
+
+```markdown
+# Differentiation Plan: [Lesson Title]
+
+**Standard:** [verbatim]  **Grade:** [X]  **Strand:** [RL/RI/W/SL/L]  **Duration:** [X min]  **Curriculum:** [name if confirmed / General]
+*Learner needs: [If no specific needs were provided: "UDL defaults applied — sentence supports and vocabulary support across all tiers." If learner needs were specified, describe them here instead.]*
+
+## Learning Objective
+[Same objective across all tiers — preserved from source lesson]
+
+## Differentiation Overview
+[1 short paragraph, ≤3 sentences: approach, text confirmed as shared across all tiers,
+prerequisite named by code + short gist (for K–5, note if the foundational literacy flag
+applies per R3.5), forward standard named by code + gist. Never paste full standard text
+here — the target standard is already verbatim in the header. Use CCSS if state uses
+CCSS/CCSS-aligned. Source from state vertical alignment when state is known; footnote CCSS code
+when using as proxy for a non-CCSS state.]
+
+## Tier Design
+[ONE `table` block — never three labeled paragraph stacks. Columns: Below (Group A) / At (Group B) / Above (Group C).
+Rows (a cell may be "—" where a field doesn't apply to that tier):
+- **Grounded in** — Below: concept-level prerequisite by code + gist from CCSS vertical
+  alignment. Above: forward standard by code + gist. At: "—".
+- **Scaffolds / extension** — fragments, ≤25 words per cell: Below scaffolds in play; At
+  supports; Above extension + which R7 quality type it meets.
+- **Conferring move** — one specific prompt per tier.
+- **Worksheet tasks** — ≤40 words per cell, written LAST: read that tier's FINAL student
+  material's blocks top-to-bottom and name every printed task in order — tasks by name with
+  their printed scaffolds (e.g. "First read (annotation guide), Central-idea organizer,
+  Summary"), every tier-only add-on or extension sub-part by its printed heading, exit
+  ticket, "If you finish early" anchor task, Reflect prompt. List items; don't restate their
+  text. Name nothing unprinted — no "on request" supports, no planned organizer the material
+  dropped. Never copy another tier's cell.]
+
+
+[Then ONE `callout` (note style): misconception / common error watch — pattern + teacher
+prompt, ≤2 sentences per tier that needs one.]
+
+[K–5 only, if applicable — a SECOND `callout` (note style), the foundational literacy flag:
+⚠ If students cannot read this text aloud fluently, comprehension scaffolds will not close
+the gap — the prerequisite need is decoding/fluency intervention delivered separately.
+Read-aloud is an appropriate access bridge while that support is in place, not a substitute
+for it.]
+
+## Formative Check
+[Two required elements:
+1. **Mid-lesson checkpoint:** A specific check during reading or writing work time — name the trigger or artifact (e.g., "After the annotation task, collect two student samples: if neither can identify the central idea, pause and re-model the annotation move before moving to the writing task"). 'Circulate and observe' does not pass.
+2. **Exit ticket with explicit sort criteria:** State what a student must produce or demonstrate to land in each bucket for THIS lesson, e.g.: "Got it — [e.g., names the central idea and cites two pieces of text evidence] / Almost there — [e.g., names the central idea but cites only one piece of evidence or misidentifies a supporting detail] / Needs re-teaching — [e.g., cannot name the central idea independently]." Generic bucket labels without lesson-specific criteria do not pass.]
+
+## Anchor Activity
+[`from_shared: anchor_activity` — the same student-facing task printed on every student material — plus one teacher-only line: when to deploy it and why it requires genuine ELA thinking]
+
+## Flexible Grouping
+[Current tier assignments, the evidence or basis for placement (e.g., "Placed based on prior writing sample / ORF score / exit ticket on [standard]" or "Default profile applied — no diagnostic data available"), and an explicit statement that groups are revisable after the formative check]
+
+## Why this works (1)
+[One specific tier design choice + reasoning]
+
+## Why this works (2)
+[A second specific tier design choice + reasoning]
+
+## Next Steps
+**Got it (exit ticket passes):** [connect to forward standard or upcoming lesson]
+**Almost there:** [targeted small-group or conferring move — specific gap to address]
+**Needs re-teaching:** [specific reteach strategy or Tier 2/3 flag if gap is persistent]
+
+```
+
+### Document content — student materials (`id: worksheet_group_a` / `worksheet_group_b` / `worksheet_group_c`)
+
+No teacher notes, look-fors, or rationale. All three include: vocabulary glossary + sentence
+frames + the "If you finish early" anchor task + open-ended reflective prompt (rubric O5 —
+UDL across all tiers) — all pulled from `shared` so they are identical across tiers by
+construction.
+
+Format by strand:
+
+| Lesson strand | Student material format |
+|---|---|
+| Reading | Reading guide: text excerpt(s) if needed, annotation prompts, comprehension tasks, response prompt |
+| Writing | Writing frame: mentor text excerpt (if in lesson), planning organizer, drafting space with scaffolds |
+| Combined | Reading tasks followed by writing tasks, scaffolds at the appropriate fade per R7 |
+
+```markdown
+# [Group A / Group B / Group C] — [Lesson Title]
+
+**Name:** _________________ **Date:** _________
+
+## Vocabulary
+[`from_shared: vocabulary` — the renderer formats the term–meaning pairs itself; never type a pipe-character table into a `text` field]
+
+**You can use these sentence supports:**
+- "The author uses ______ to show ______."
+- "My claim is ______. One reason is ______."
+
+---
+
+[Tasks pulled ONE AT A TIME, each with its scaffold directly above it — per task N:
+at most ONE scaffold block (Below only, R7 fade: Task 1's block may combine a primary +
+secondary scaffold if genuinely different modes; Task 2 gets one lighter scaffold; Task 3+
+gets none — the absence is intentional and silent), then
+`{"type": "from_shared", "key": "tN", "label": "N"} followed by a workspace block`. Task text identical on all three
+tiers; never re-typed. Writing space after each task is automatic — do not add answer
+boxes for tasks.]
+[Tier-only add-ons (e.g. Above "Go further" extension) as their own headed sections]
+
+---
+
+## If you finish early
+[`from_shared: anchor_activity` — identical block on all three tiers]
+
+## Reflect
+[`from_shared: reflect_prompt` — identical question on all three tiers]
+```
+
+---
+
+## Writing differentiation.json — ELA mapping
+
+- `shared.subject`: `"ELA"`
+- `shared.anchor_task`: the shared text + essential question
+- `shared.t1`..`tN`: the core reading/writing tasks shared by ALL tiers, one task per key — faceted {teacher: "the difficulty and what to watch for, as a plain sentence", student: <the task>}
+- Teacher document: differentiation plan, max 3 pages; student materials max 2 pages each
+- **Copyright:** do NOT reproduce the source lesson's student-facing text verbatim — rewrite as original content.

--- a/skill-library/k12-lesson-differentiation/references/example_differentiation.json
+++ b/skill-library/k12-lesson-differentiation/references/example_differentiation.json
@@ -1,0 +1,519 @@
+{
+  "shared": {
+    "subject": "Mathematics",
+    "grade": "Grade 4",
+    "standard_code": "4.NF.B.3.d",
+    "standard_text": "Solve word problems involving addition and subtraction of fractions referring to the same whole and having like denominators, e.g., by using visual fraction models and equations to represent the problem.",
+    "t1": {
+      "teacher": "Core task — watch for adding denominators (3/8 + 2/8 = 5/16).",
+      "student": "Maria's family ate 3/8 of a veggie pizza and 2/8 of the same pizza later. How much of the pizza did they eat in all?"
+    },
+    "t2": {
+      "teacher": "Stretch task — subtraction from the combined amount; expect tape-diagram or equation strategies.",
+      "student": "After eating, 1/8 of the pizza fell on the floor. How much pizza is left to share?"
+    },
+    "exit_ticket": {
+      "teacher": "Sort responses: *Got it* — correct with a convincing picture or equation; *Almost there* — right answer, shaky justification; *Needs re-teaching* — added denominators.",
+      "student": "Jon says 4/6 + 1/6 = 5/12. Is he right? Use a picture or equation to prove your answer."
+    },
+    "vocabulary": {
+      "type": "table",
+      "rows": [
+        [
+          "denominator",
+          "The bottom number of a fraction — how many equal parts the whole is split into."
+        ],
+        [
+          "like denominators",
+          "Fractions whose wholes are split into the same number of parts."
+        ]
+      ]
+    },
+    "sentence_frames": {
+      "type": "labeled",
+      "label": "Finish these sentences",
+      "text": "I know ____________ and ____________. The part I don't know is ____________.\nMy strategy was ____________ because ____________."
+    },
+    "misconceptions": {
+      "type": "table",
+      "headers": [
+        "What students do",
+        "Why it happens",
+        "Teacher move"
+      ],
+      "rows": [
+        [
+          "Adds denominators as well as numerators (3/8 + 2/8 = 5/16)",
+          "Treats numerator and denominator as separate whole numbers",
+          "Return to the tape diagram: how many eighths in all?"
+        ]
+      ]
+    },
+    "anchor_activity": "Finished early? Choose one problem from this page and prove your answer a second way, using a tape diagram. Then write one new question about the pizza whose answer is more than one whole, and solve it.",
+    "reflect_prompt": "What strategy did you use and why?"
+  },
+  "theme": {
+    "primary": "#17A267"
+  },
+  "documents": [
+    {
+      "id": "teacher_plan",
+      "audience": "teacher",
+      "eyebrow": "Grade 4 Mathematics · Differentiation Plan",
+      "title": "Adding Fractions with Like Denominators — Differentiation Plan",
+      "meta": "4.NF.B.3.d · 60 minutes · Below (Group A) / At (Group B) / Above (Group C)",
+      "sections": [
+        {
+          "heading": "Overview",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "standard"
+            },
+            {
+              "type": "paragraph",
+              "text": "All three tiers work the same pizza context with the same core problems. Only the supports differ."
+            },
+            {
+              "type": "from_shared",
+              "key": "t1",
+              "label": "1"
+            },
+            {
+              "type": "from_shared",
+              "key": "t2",
+              "label": "2"
+            },
+            {
+              "type": "from_shared",
+              "key": "exit_ticket"
+            }
+          ]
+        },
+        {
+          "heading": "Flexible grouping",
+          "blocks": [
+            {
+              "type": "labeled",
+              "label": "Basis",
+              "text": "Default profile applied — no diagnostic data available. If you have a recent fractions exit ticket or work sample, place students from that instead."
+            },
+            {
+              "type": "labeled",
+              "label": "Revisable",
+              "text": "Tier placement holds for this lesson only. Regroup on today's exit ticket: a Below student who solves Problem 2 unaided moves up; anyone who adds the denominators works with the Below supports tomorrow."
+            }
+          ]
+        },
+        {
+          "heading": "Below tier (Group A)",
+          "blocks": [
+            {
+              "type": "labeled",
+              "label": "Grounded in prerequisite",
+              "text": "3.NF.A.1 — Understand a fraction 1/b as the quantity formed by 1 part when a whole is partitioned into b equal parts."
+            },
+            {
+              "type": "from_shared",
+              "key": "misconceptions"
+            },
+            {
+              "type": "labeled",
+              "label": "Worksheet tasks",
+              "text": "P1 (shaded-diagram entry task + know/need table), P2, exit ticket, 'If you finish early' anchor task, Reflect prompt."
+            }
+          ]
+        },
+        {
+          "heading": "At tier (Group B)",
+          "blocks": [
+            {
+              "type": "labeled",
+              "label": "Worksheet tasks",
+              "text": "P1, P2, exit ticket, 'If you finish early' anchor task, Reflect prompt."
+            }
+          ]
+        },
+        {
+          "heading": "Above tier (Group C)",
+          "blocks": [
+            {
+              "type": "labeled",
+              "label": "Worksheet tasks",
+              "text": "P1, P2, 'Go further' extension (write-your-own problem + error-explanation problem), exit ticket, 'If you finish early' anchor task, Reflect prompt."
+            }
+          ]
+        },
+        {
+          "heading": "Why this works (1)",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "The Below tier keeps both grade-level problems and adds a shaded-diagram entry and a know/need table before Problem 1 only. Students act on the model before the symbols, so the standard's full demand stays while the entry cost drops — and the scaffold fades by Problem 2."
+            }
+          ]
+        },
+        {
+          "heading": "Why this works (2)",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "The Above extension asks students to write and critique problems rather than compute more of them. Authoring a sum-greater-than-one story and explaining a wrong answer deepen 4.NF.B.3.d instead of moving past it, and both reuse the shared pizza context so tiers stay comparable."
+            }
+          ]
+        },
+        {
+          "heading": "Formative check",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "Collect the exit ticket from every tier and sort into three piles: correct with a matching model; adds the denominators; miscounts the shaded parts."
+            },
+            {
+              "type": "labeled",
+              "label": "Next day",
+              "text": "Denominator pile re-enters through the shaded diagram; miscount pile recounts a partitioned model with you; correct pile starts on the anchor task."
+            }
+          ]
+        },
+        {
+          "heading": "Anchor activity",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "anchor_activity"
+            },
+            {
+              "type": "labeled",
+              "label": "Deployment",
+              "text": "Printed on all three worksheets. Deploy after the exit ticket; standard-aligned because proving with a tape diagram and generating a sum-greater-than-one problem both exercise 4.NF.B.3.d."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "worksheet_group_a",
+      "audience": "student",
+      "eyebrow": "Grade 4 Mathematics · 4.NF.B.3.d",
+      "title": "Group A — Pizza Fractions",
+      "meta": "Name: ____________________    Date: ____________",
+      "sections": [
+        {
+          "heading": "Vocabulary",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "vocabulary"
+            }
+          ]
+        },
+        {
+          "heading": "Sentence supports",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "sentence_frames"
+            }
+          ]
+        },
+        {
+          "heading": "Problems",
+          "blocks": [
+            {
+              "type": "labeled",
+              "label": "For Problem 1 — try it with the diagram",
+              "text": "The pizza below is cut into 8 equal slices. Shade the slices Maria's family ate first, then shade the slices they ate later in a different way."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "What I know",
+                "What I need to find"
+              ],
+              "rows": [
+                [
+                  "",
+                  ""
+                ]
+              ],
+              "empty_row_height_pt": 26
+            },
+            {
+              "type": "from_shared",
+              "key": "t1",
+              "label": "1"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "from_shared",
+              "key": "t2",
+              "label": "2"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 80
+            }
+          ]
+        },
+        {
+          "heading": "Show what you know",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "exit_ticket"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 90
+            }
+          ]
+        },
+        {
+          "heading": "If you finish early",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "anchor_activity"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 90
+            }
+          ]
+        },
+        {
+          "heading": "Reflect",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "reflect_prompt"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 60
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "worksheet_group_b",
+      "audience": "student",
+      "eyebrow": "Grade 4 Mathematics · 4.NF.B.3.d",
+      "title": "Group B — Pizza Fractions",
+      "meta": "Name: ____________________    Date: ____________",
+      "sections": [
+        {
+          "heading": "Vocabulary",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "vocabulary"
+            }
+          ]
+        },
+        {
+          "heading": "Sentence supports",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "sentence_frames"
+            }
+          ]
+        },
+        {
+          "heading": "Problems",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "t1",
+              "label": "1"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "from_shared",
+              "key": "t2",
+              "label": "2"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 100
+            }
+          ]
+        },
+        {
+          "heading": "Show what you know",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "exit_ticket"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 90
+            }
+          ]
+        },
+        {
+          "heading": "If you finish early",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "anchor_activity"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 90
+            }
+          ]
+        },
+        {
+          "heading": "Reflect",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "reflect_prompt"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 60
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "worksheet_group_c",
+      "audience": "student",
+      "eyebrow": "Grade 4 Mathematics · 4.NF.B.3.d",
+      "title": "Group C — Pizza Fractions",
+      "meta": "Name: ____________________    Date: ____________",
+      "sections": [
+        {
+          "heading": "Vocabulary",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "vocabulary"
+            }
+          ]
+        },
+        {
+          "heading": "Sentence supports",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "sentence_frames"
+            }
+          ]
+        },
+        {
+          "heading": "Problems",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "t1",
+              "label": "1"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "from_shared",
+              "key": "t2",
+              "label": "2"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 100
+            }
+          ]
+        },
+        {
+          "heading": "Go further",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "Write your own fraction story problem where the answer is 7/8. Then write a second one where someone could make the mistake of adding the denominators — and explain how you would help them see the error."
+            },
+            {
+              "type": "workspace",
+              "height_pt": 110
+            }
+          ]
+        },
+        {
+          "heading": "Show what you know",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "exit_ticket"
+            },
+            {
+              "type": "workspace",
+              "size": "large"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 90
+            }
+          ]
+        },
+        {
+          "heading": "If you finish early",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "anchor_activity"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 90
+            }
+          ]
+        },
+        {
+          "heading": "Reflect",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "reflect_prompt"
+            },
+            {
+              "type": "workspace",
+              "height_pt": 60
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/skill-library/k12-lesson-differentiation/references/learning-commons-kg.md
+++ b/skill-library/k12-lesson-differentiation/references/learning-commons-kg.md
@@ -1,0 +1,136 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Learning Commons Knowledge Graph — call sequences (differentiation)
+
+Used by `k12-lesson-differentiation` Step 2 **only when the LC Knowledge Graph connector is
+available**. If it is not connected, skip this file entirely (SKILL.md Step 2 has the fallback).
+Each section below is the call sequence for one subject. Calling the KG when connected is
+mandatory; not calling it is a critical failure.
+
+## Resolving the standard (all subjects)
+
+Resolve the standard with `find_standard_statement`, passing `academicSubject` and `jurisdiction` (the U.S. state) when they're known:
+
+- **A code is provided** (named in the source lesson or by the teacher): search by code — `find_standard_statement(code=<code>, academicSubject="<subject>")`. A code search matches both the code itself and everything beneath it (prefix match): a leaf like `3.NF.A.1` returns just that standard, while a parent like `2.OA` returns `2.OA` plus all `2.OA.*`. **If it returns nothing**, the code's format probably doesn't match the graph's — fall back to keyword search (below); its results come back with real `code` values that reveal the correct format, which you can use to retry the code search.
+- **No code provided**: start with keyword search — `find_standard_statement(keywords=["<word or phrase>", "<word or phrase>", …], academicSubject="<subject>")`. `keywords` is a **list** of topic words/phrases; a standard matches if ANY of them appears in its description. Pick the best-matching standard from the returned `standards` array — its `code` can seed a follow-up code search for related standards (e.g. its parent prefix to pull the whole family).
+
+When a returned standard has children, they come back in its `subStandards` array — use whichever is most relevant to the user's request, the standard itself or one of its sub-standards.
+
+From the chosen standard, extract: the verbatim statement text, its `code`, and `caseIdentifierUUID` (store — required for all subsequent calls).
+
+## Mathematics
+
+
+**Call all three before drafting. Not calling when connected is a critical failure.**
+
+Note any standard code the source lesson names — the resolution step searches by it when present.
+
+After the standard resolves, the progression calls (both directions), misconceptions, and learning components all depend only on its `caseIdentifierUUID` — issue those four as one parallel batch, each with its full parameters as specified below. Step 5 runs on its own terms (its own lookup modes and teacher confirmation), untouched by the batch.
+
+**Available tools:** `find_standard_statement`, `find_standards_progression_from_standard`, `find_misconceptions_for_standard`, `find_learning_components_from_standard`, `find_curriculum_lessons`, `find_materials_for_lesson`.
+
+1. **Standard**: Resolve the standard per *Resolving the standard* above with
+   `academicSubject="Mathematics"` and, when state is known from Step 0 state detection,
+   `jurisdiction="<state>"` → verbatim statement text and `caseIdentifierUUID`.
+
+   When jurisdiction is passed and the KG returns a state-specific standard, use that
+   standard's code and text verbatim. Only use the CCSS fallback chain in math.md R3 if the teacher's state is not known or inferrable.
+
+2. **Prerequisite and forward standard**: Call `find_standards_progression_from_standard(caseIdentifierUUID, direction="backward")` → extract the single primary prerequisite standard, verbatim — this grounds the Below tier. Call `find_standards_progression_from_standard(caseIdentifierUUID, direction="forward")` → extract the single primary forward standard, verbatim — this grounds the Above tier. Omitting either is a critical failure.
+
+3. **Misconceptions**: Call `find_misconceptions_for_standard(caseIdentifierUUID, subject="Mathematics")` → extract the 3 most relevant misconceptions. For each, keep only the student behavior and the teacher move, rewritten in your own words. If no results, draft 3 from training knowledge.
+
+4. **Learning components** (optional, for teacher plan): Call `find_learning_components_from_standard(caseIdentifierUUID)` → extract up to 5 sub-skill descriptions. Use to verify R2: all components must appear across all tiers.
+
+5. **IM lesson materials** (only when BOTH conditions hold: IM is confirmed as the curriculum AND the teacher named the lesson — Scenario B3 — rather than uploading or linking it): Call `find_curriculum_lessons` with `author="Illustrative Mathematics"`. Use the mode that matches what the teacher provided:
+   - **Teacher named by position** (e.g., "Grade 6, Unit 2, Lesson 3"): use `ordinalName="Grade N, Unit N, Lesson N"`. Expand abbreviations first.
+   - **Teacher named by title**: use `lessonName="<content words from the title>"`. No grade/unit/lesson numbers.
+
+   If multiple candidates return, echo `fullOrdinalName` and `lessonName` back to the teacher to confirm. Once confirmed, call `find_materials_for_lesson(lessonIdentifier, materialSource=["lesson", "activity"])` → extract: (a) activity names and sequence, (b) problem types and unknown positions addressed, (c) discourse moves. Use to ground tier task design in the actual lesson structure — do not reproduce student-facing text verbatim.
+
+   If the teacher uploaded or linked the lesson (Scenarios B or B2), skip this step — lesson content is already available.
+
+**Curriculum-terminology check (if not IM-confirmed):** Before proceeding, scan your working notes and verify they contain zero mentions of "Illustrative Mathematics," "IM," any MLR name (MLR 1–8), "Compare and Connect," "Stronger and Clearer Each Time," or any IM lesson/activity title. Remove any that remain — a teacher who has not confirmed IM must not receive IM-specific terminology in any tier document, the teacher plan, or chat (the same rule as SKILL.md's Copyright guardrail).
+
+**If KG not connected:** proceed from best knowledge; add footer to teacher plan: *"Generated without the Learning Commons KG. Prerequisite grounding and misconceptions reflect general best practice."*
+
+---
+
+## ELA
+
+
+**Call these tools before drafting. Not calling when connected is a critical failure.**
+
+Note any standard code the source lesson names — the resolution step searches by it when present.
+
+**CCSS strand detection:** CCSS ELA standards have distinct strands — Reading Literature (RL), Reading Informational (RI), Writing (W), Speaking and Listening (SL), and Language (L). Identify which strand the standard belongs to before calling the KG. This shapes how the differentiation is structured (e.g., the below-tier scaffold for a writing standard looks different than for a reading standard).
+
+1. Resolve the standard per *Resolving the standard* above with
+   `academicSubject="English Language Arts"` and, when state is known from Step 0 state
+   detection, `jurisdiction="<state>"` → verbatim standard text, its `code`, and
+   `caseIdentifierUUID`.
+
+   When jurisdiction is passed and the KG returns a state-specific standard, use that
+   standard's code and text verbatim.
+
+2. `find_learning_components_from_standard(caseIdentifierUUID)` → up to 5 sub-skill descriptions. **Call this for K-2 standards only; for grades 3+, learning components are not yet available in the KG — skip this call and draft sub-skills from the standard statement.** Use sub-skills to verify R2: all learning components must remain in scope across all three tiers.
+
+**ELA progressions:** `find_standards_progression_from_standard` does not return data for ELA standards — do not call it. Source prerequisite and forward standards from CCSS vertical alignment knowledge for the appropriate strand (e.g., the prior grade's parallel standard, the next grade's parallel standard). Add a footer note to the teacher plan: *"Standard text retrieved from the Learning Commons KG. Prerequisite and forward standard grounding reflects CCSS [strand] vertical alignment."*
+
+**If KG not connected:** proceed from best knowledge; add footer to teacher plan: *"Generated without the Learning Commons KG. Standard text, prerequisite grounding, and learning components reflect general best practice."*
+
+---
+
+## Science
+
+
+**Call all three before drafting. Not calling when connected is a critical failure.**
+
+Note any NGSS Performance Expectation code the source lesson names — the resolution step searches by it when present.
+
+**Available tools:** `find_standard_statement`, `find_curriculum_lessons`, `find_materials_for_lesson`.
+
+Note: `find_learning_components_from_standard` and `find_standards_progression_from_standard` do **not** return data for science standards — do not call them.
+
+1. **Standard**: Resolve the standard per *Resolving the standard* above with
+   `academicSubject="Science"` and, when state is known from Step 0 state detection,
+   `jurisdiction="<state>"`. Texas uses TEKS Science — pass `jurisdiction="Texas"` if the teacher's state is Texas. PE verbatim text + `caseIdentifierUUID`.
+
+   When jurisdiction is passed and the KG returns a state-specific standard, use that
+   standard's code and text verbatim.
+
+2. **Find the source lesson in the KG** using `find_curriculum_lessons` with `author="OpenSciEd"`. This call serves double duty: it retrieves lesson context AND, for Scenario B3, it is how the lesson is identified in the first place (the teacher named it rather than uploading or linking it). Use exactly ONE mode per call:
+
+   - **Curriculum position known** (teacher named the lesson by position — Scenario B3 — or unit/lesson number is visible in the uploaded/fetched lesson — e.g., "Science Grade 5, Unit 2, Lesson 3"): use `ordinalName="Science Grade 5, Unit 2, Lesson 3"`. Expand abbreviations before passing (G5 U2 L3 → Science Grade 5, Unit 2, Lesson 3). This is the most precise mode; prefer it when available.
+   - **Title known but no position** (teacher named the lesson by title — Scenario B3 — or title is visible in the uploaded/fetched source): use `lessonName="<words from the lesson title>"`. Pass distinctive content words only — omit grade/unit/lesson numbers. Results come back best-match-first.
+   - **Standard UUID only** (uploaded/fetched lesson with no recoverable position or title — not applicable for Scenario B3): use `caseIdentifierUUID=<uuid from step 1>`. Note: OpenSciEd lessons align to Multi-State (NGSS) standards only — a state-specific PE UUID with no exact crosswalk returns no results.
+
+   If multiple candidates return, echo their `fullOrdinalName` and `lessonName` back to the teacher to confirm which lesson is meant before fetching materials. Once confirmed, call **`find_materials_for_lesson(lessonIdentifier)`** → extract: (a) anchoring phenomenon; (b) unit driving question; (c) this lesson's investigative phenomenon or question; (d) lesson position in the unit storyline; (e) which SEPs and CCCs are foregrounded; (f) any routines or activity structures used.
+
+3. **Progression.** From the lesson materials or KG data, identify: (a) the prior-grade PE or DCI element that the below-level scaffold should route students *up from*; (b) the forward PE that the above-level extension should preview. Name both verbatim. Omitting either is a critical failure.
+
+**If KG not connected:** proceed from best knowledge; add footer to teacher plan: *"Generated without the Learning Commons KG. PE grounding, OpenSciEd alignment, and progression reflect general best practice."*
+
+---
+
+## Social Studies
+
+
+**Call all queries before drafting. Not calling when connected is a critical failure.**
+
+Note any standard code the source lesson names — the resolution step searches by it when present.
+
+1. **Standard**: Resolve the standard per *Resolving the standard* above with `academicSubject="Social Studies"` and `jurisdiction="<state>"` (required — `Multi-State` carries no Social Studies standards) → verbatim statement text, its `code`, and `caseIdentifierUUID` (store — required for all subsequent calls). Use statement text verbatim in all output.
+
+**Note on standard progressions:** `find_standards_progression_from_standard` does not return data for social studies standards — do not call it. Source prerequisite and forward standards from state standards vertical alignment knowledge (e.g., adjacent grade standards in the same strand). Add a footer to the teacher plan: *"Standard text retrieved from the Learning Commons KG. Prerequisite and forward standard grounding reflects [state] standards vertical alignment."*
+
+**If KG not connected:** proceed from best knowledge; add footer to teacher plan: *"Generated without the Learning Commons KG. Standard text, prerequisite grounding, and misconceptions reflect general best practice."*
+
+→ **KG phase complete. Proceed immediately to Step 3.**
+
+---
+

--- a/skill-library/k12-lesson-differentiation/references/math.md
+++ b/skill-library/k12-lesson-differentiation/references/math.md
@@ -1,0 +1,326 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Math — differentiation pedagogy
+
+Loaded by `k12-lesson-differentiation` when the subject is **math**.
+
+## Identify the source lesson and curriculum
+
+**Detect IM use.** Before anything else, check whether the teacher is using Illustrative Mathematics. Look for signals anywhere in the conversation: explicit name ("IM", "Illustrative Mathematics", "IM 360"), IM-specific terminology (MLRs, cool-down, "Stronger and Clearer Each Time", launch-explore-discuss structure, IM unit or lesson references), or an uploaded IM teacher guide. If confirmed, treat as **IM-confirmed** throughout — use IM discourse language and structures in the teacher plan.
+
+Then detect which scenario applies:
+
+**Scenario A — Source lesson exists in the prior conversation**
+If a lesson was produced or discussed earlier in this conversation, use it directly. Do NOT re-ask the teacher to share it.
+
+**Scenario B — Teacher uploads a source lesson**
+Read the file first. Confirm: grade level, subject, standard, learning objective, lesson structure. If the file is unreadable on first attempt, surface the error clearly and ask the teacher to re-share. Do NOT silently fabricate a lesson.
+
+**Scenario B2 — Teacher links a source lesson by URL**
+Fetch the URL and read its content first. Then confirm grade level, subject, standard, learning objective, and lesson structure exactly as in Scenario B. If the fetch fails or returns unusable content, surface the error clearly and ask the teacher to paste the lesson text or upload the file. Do NOT silently fabricate a lesson.
+
+**Fetching the lesson completes Step 1 only — it does NOT replace standards grounding.** Continue to Step 2 — Ground in standards. Skipping Step 2 after a URL fetch is the same critical failure as skipping it for an uploaded lesson.
+
+**Scenario C — No source lesson present**
+Ask before proceeding:
+> "Happy to differentiate. Do you have a specific lesson in mind? You can paste it, share a file, or tell me the grade + topic + standard and I'll work from that."
+
+---
+
+## Standards grounding
+
+Follow **Step 2 — Ground in standards** in SKILL.md: if the Learning Commons Knowledge Graph
+is connected, use the Math section of `references/learning-commons-kg.md`; if not,
+proceed from best knowledge and add the disclaimer footer to the teacher plan.
+
+## The differentiation rules
+
+Apply all eight rules to every differentiated lesson.
+
+### R1 — Output structure
+
+**1 cohesive teacher-facing differentiation plan + 3 pure student-ready worksheets. NEVER 3 hybrid per-level lesson plans.**
+
+The hybrid pattern — 3 per-level documents each mixing teacher notes and student problems — is a specific failure mode. The teacher plan covers all levels in one document; the worksheets are student-only.
+
+### R2 — Standard scope preservation
+
+**Every level addresses the original standard. Every standard element stays in play across all levels — including the hard cases.**
+
+The standard's hardest case is exactly what below-level students most need to encounter with scaffolds, not the case to drop. Reducing the standard's cognitive scope for below-level students is not differentiation.
+
+**Engagement must be preserved at the Below tier.** Do not assign interesting real-world problem contexts to At/Above and procedural drill to Below. The same scenario, the same hook — with different supports. This is both a rigor and equity requirement.
+
+### R3 — Teach-up via named prerequisite
+
+**Below-level scaffolds route students UP to grade-level work, grounded in a named prerequisite. Not "just easier."**
+
+- ✓ "Below-level uses [visual model] to surface the [concept] from [prior standard]; students apply that representation to the grade-level problem."
+- ✗ "Below-level uses simpler numbers / shorter text / fewer steps."
+
+#### Standards framework detection
+
+Before identifying the prerequisite, determine which framework the teacher's standard belongs to. Run the following fallback chain and stop at the first step that yields a result:
+
+1. KG lookup — call find_standards_progression_from_standard with the teacher's standard code. If the KG returns a predecessor standard for the teacher's framework, use it verbatim. This is the preferred path regardless of whether the framework is CCSS, TEKS, or another state system.
+
+2. **Partial match** — the closest Common Core prerequisite standard(s) plus their **learning components** (the standard broken into smaller sub-skills). The teacher's framework has no exact equivalent, so present the standard as a CCSS proxy, and use the learning components to pick the specific prior sub-skill the Below-tier scaffold builds from.
+**Output rule for non-CCSS frameworks:** When the CCSS proxy path is taken, do not put CCSS
+codes in the main teacher plan body. Use plain-language descriptions instead:
+- In Differentiation Overview: "Below-tier scaffolds build from prior understanding of
+  [concept description], the prerequisite for [grade-level concept]."
+- In Grounded in prerequisite: "Prerequisite concept: [plain description] — aligns to
+  [CCSS proxy code] as reference, used because TEKS progressions are not yet in the KG."
+- Move the CCSS code to a single footnote at the bottom of the teacher plan: "* Prerequisite
+  grounding uses CCSS [code] as the closest aligned standard for TEKS [teacher's code]."
+A Texas teacher's plan should not contain CCSS codes in prominent positions.
+
+3. **Concept-level fallback** — if no CCSS analog exists, describe the prerequisite as a concept in plain language: *"Prerequisite concept: [description] — specific standard not available for this state framework."*
+
+The teacher plan's **Grounded in prerequisite** line must reflect which path was taken. Never leave this line blank or generic — a concept-level description is always achievable even when a standard code is not.
+
+**Why prerequisites are non-negotiable in math.** Unlike ELA or science, where "same objective, different access" is often sufficient, math learning is compounding: a student without the prior-grade concept cannot make sense of the current one through scaffolding alone. The prerequisite gap is typically the actual obstacle, not the current-grade concept. Designing around prerequisite identification — as is appropriate for other subjects — would be a pedagogical compromise in math.
+
+#### CRA entry point
+
+| Tier | CRA entry point |
+|---|---|
+| Below | Concrete (manipulative or physical model) → Representational (diagram, visual model) |
+| At | Representational → Abstract (symbolic, numeric) |
+| Above | Abstract → Connection (generalization, structural insight, forward standard) |
+
+### R4 — Below-level scaffolds
+
+**Scaffolds support thinking without revealing answers. NEVER answer-revealing hints. NEVER keyword strategies.**
+
+Failure modes:
+- ❌ Keyword strategies ("Look for 'together' — that means combining") — undermines standards that test against shortcuts
+- ❌ Algorithm pre-teaching before conceptual understanding
+- ❌ Pre-filled templates leaving only the answer blank
+- ❌ Multiple-choice when original task requires open production
+
+Acceptable scaffolds:
+- ✓ Sentence supports: "I know ____ and ____. The part I don't know is ____."
+- ✓ Visual organizers matched to the mathematical concept (see table).
+- ✓ Manipulative or concrete prompts bridging to the abstract task (CRA per R3)
+- ✓ Word banks for vocabulary (not for choosing the answer)
+- ✓ Reduced complexity with explicit transfer step: "Try with these first, then apply to the original problem."
+
+#### Concept → primary visual model
+
+| Math concept type | Primary visual model |
+|---|---|
+| Part-whole / additive reasoning | Tape diagram or part-whole diagram |
+| Multiplicative / ratio / rate reasoning | Double number line or ratio table |
+| Fractions as quantities on a number line | Number line |
+| Area / multiplication structure | Area model or array |
+| Proportional relationships / linear functions | Table of values or coordinate graph |
+| Algebraic structure / equation reasoning | Equation balance model or variable representation |
+| Geometric relationships | Labeled diagram with annotated parts |
+
+#### Scaffold density cap
+
+**Cap embedded scaffolds at 1–2 per problem.**
+
+| Type | Counts toward cap? |
+|---|:-:|
+| Embedded — printed on every problem (organizer, sentence support, hint text) | YES |
+| Header-level — vocabulary box, sentence supports at top of worksheet | NO |
+| Teacher-side — manipulatives on request, conferring prompts | NO |
+
+Pick a primary scaffold first. Only add a second if it contributes a genuinely different mode. If the second does the same cognitive work as the primary, drop it.
+
+### R5 — Required pedagogical infrastructure
+
+**Every differentiated lesson must include all four:**
+
+| Section | What it is | Where |
+|---|---|---|
+| **Formative check** | Tiered exit ticket or mid-lesson prompt. Not "monitor students." | Teacher plan + per-level worksheet |
+| **Anchor activity** | Standard-aligned task for early finishers. Not busywork. Written student-facing in `shared.anchor_activity` and printed on every worksheet — an anchor activity that exists only as a plan description is a failure. | Teacher plan + all three worksheets |
+| **Flexible-grouping language** | Tier assignments tied to THIS lesson's evidence, explicitly revisable after the formative check. Not static ability tracks. | Teacher plan |
+| **Per-level misconception notes** | Error pattern + teacher prompt + small-group signal. KG-sourced when available. | Teacher plan |
+
+**Every worksheet ends with one open-ended reflective prompt, on all three tiers** — e.g., "Explain your thinking," "What strategy did you use and why?" Not optional for any tier. Store it as `shared.reflect_prompt` and name it in each tier's **Worksheet tasks** line in the teacher plan — a printed task the plan never mentions is a failure. (Rubric R3.)
+
+### R6 — Invisible modifications
+
+**Same story / same context / same core problem across levels. Only the supports differ.**
+
+What can differ: scaffolds on the worksheet; teacher conferring supports; extension prompt depth.
+
+What must NOT differ: the problem context; the core question; the structural challenge the standard targets.
+
+**Do not announce scaffold removals to students.** If a scaffold appears on Problem 1 but not Problem 3, its absence is silent — no label, aside, or comment (e.g., no "(No organizer this time)" or "Try it without the diagram"). The scaffold simply does not appear; students encounter the problem on its own terms.
+
+Same numbers by default. Numbers may change for Below only if mathematical structure is fully preserved — do not eliminate the key challenge (e.g., do not convert fractions to whole numbers).
+
+### R7 — Within-level progressive scaffolding
+
+**Each worksheet sequences problems with progressive cognitive demand.**
+
+#### Below-level fade pattern
+
+| Problem | Embedded scaffolds | Pattern |
+|---|:-:|---|
+| Problem 1 | Up to 2 | Scaffolded |
+| Problem 2 | Up to 1 | Guided |
+| Problem 3+ | 0 embedded | Independent |
+| Exit ticket | 0–1 | Mastery check |
+
+#### Above-level extension quality test
+
+Every above-level extension must answer: **what new thinking does this require that the at-level student isn't already doing?**
+
+| Type | What it requires |
+|---|---|
+| New cognitive operation | At-level applies; above-level analyzes, evaluates, or creates (Bloom/DOK shift) |
+| Structural insight | Generalization, equivalence, or inverse relationship the at-level treats as a single instance |
+| Forward-standard preview | A real conceptual element from a higher-grade standard — not just notation or vocabulary |
+| Open generative task | Student writes a problem, designs a counterexample, or constructs an argument from scratch |
+
+Reject if: notation swap only, more of the same, or restatement.
+
+### R8 — Scope and defaults
+
+**If tier scope is not specified, ask ONE combined question:**
+
+> "I'll differentiate this into below / at / above grade-level tiers — are those the right three? And any specific learner needs I should know about? If not, I'll apply UDL defaults (sentence stems and vocabulary support across all tiers)."
+
+**Defaults applied silently:**
+- Tiers: below / at / above
+- UDL features: sentence stems and vocabulary glossary in **all three** student worksheets (not Below only — rubric O5)
+- Scope: full lesson including exit ticket
+
+**FA follow-up prompt — ask after generating the default plan:**
+
+> "Do you have any exit ticket results, diagnostic scores, or notes on where students got stuck — for example, whether they understood the concept but lost the procedure, or seemed confused about what the concept means?"
+
+This prompt fires *after* the tiered plan is delivered, not before. In math, FA data can change which scaffold type is appropriate (conceptual vs. procedural), not just refine an existing approach — the highest-stakes follow-up of any subject. Even informal teacher observation ("they froze when I showed them the area model") is useful signal for targeting the prerequisite warm-up.
+
+---
+
+### Document content — teacher plan (`id: teacher_plan`) — max 3 pages
+
+**Length budget: ~1,200 words rendered (the 3-page cap in practice).** Tighten the tier
+sections and overview before touching the closers (Flexible Grouping, Why this works, Next
+Steps) — the most common overrun is a Worksheet tasks line that restates worksheet content
+instead of naming it. **"Why this works (1)" and "Why this works (2)" are required and cannot
+be dropped to meet the length budget — cut tier section prose first.**
+
+The outline below defines the content and order of the teacher plan document's `sections`:
+each `##` heading becomes one section, its body becomes that section's blocks (use
+`from_shared` blocks for the standard, misconceptions, and exit ticket; `labeled` blocks for
+the bold fields).
+
+```markdown
+# Differentiation Plan: [Lesson Title]
+
+**Standard:** [verbatim]  **Grade:** [X]  **Duration:** [X min]  **Curriculum:** [IM / General]
+*Learner needs: [If no specific needs were provided: "UDL defaults applied — sentence supports and vocabulary support across all tiers." If learner needs were specified, describe them here instead.]*
+
+## Learning Objective
+[Same objective across all tiers — preserved from source lesson]
+
+## Differentiation Overview
+[1 short paragraph, ≤3 sentences: approach, prerequisite named by code + short gist,
+forward standard named by code + short gist. Never paste full standard text here — the
+target standard is already verbatim in the header. Use KG-returned state standard (preferred when state is known and KG has it), CCSS proxy with reference in footnote, or concept-level fallback.]
+
+## Tier Design
+[ONE `table` block — never three labeled paragraph stacks. Columns: Below (Group A) / At (Group B) / Above (Group C).
+Rows (a cell may be "—" where a field doesn't apply to that tier):
+- **Grounded in** — Below: prerequisite by code + gist (or "CCSS proxy: [code]" / "Prerequisite
+  concept: [description]" per whichever R3 path applied). Above: forward standard by code +
+  gist. At: "—".
+- **Scaffolds / extension** — fragments, ≤25 words per cell: Below scaffolds in play; At
+  supports; Above extension + which R7 quality type it meets.
+- **Conferring move** — one specific prompt per tier.
+- **Worksheet tasks** — ≤40 words per cell, written LAST: read that tier's FINAL worksheet
+  document's blocks top-to-bottom and name every printed task in order — problems by number
+  with their printed scaffolds (e.g. "P1 (tape diagram + frame), P2 (frame), P3"), every
+  tier-only add-on or extension sub-part by its printed heading, exit ticket, "If you finish
+  early" anchor task, Reflect prompt. List items; don't restate their text. Name nothing
+  unprinted — no "on request" supports, no planned organizer the worksheet dropped. Never
+  copy another tier's cell.]
+
+[Then ONE `callout` (note style): misconception watch — pattern + teacher prompt, ≤2
+sentences per tier that needs one. Never bury these in the table or a paragraph.]
+
+## Formative Check
+[Two required elements:
+1. **Mid-lesson checkpoint:** A specific check during work time — name the trigger or artifact (e.g., "After P2, scan whiteboards: if fewer than half show a correct representation, pause and remodel with a tape diagram before P3"). 'Circulate and observe' does not pass.
+2. **Exit ticket with explicit sort criteria:** State what a student must produce or demonstrate to land in each bucket for THIS lesson, e.g.: "Got it — [e.g., solves a parallel problem and explains strategy in a sentence] / Almost there — [e.g., correct answer but no explanation or one step missing] / Needs re-teaching — [e.g., cannot set up the representation independently]." Generic bucket labels without lesson-specific criteria do not pass.]
+
+## Anchor Activity
+[`from_shared: anchor_activity` — the same student-facing task printed on every worksheet — plus one teacher-only line: when to deploy it and why it requires mathematical reasoning]
+
+## Flexible Grouping
+[One bullet per tier, ≤15 words each: the placement signal for that tier.]
+[Then ONE sentence: evidence basis (e.g., "Placed based on prior exit ticket on [standard]"
+or "Default profile applied — no diagnostic data available").]
+*Groups are revisable — revisit after the formative check.*
+
+## Why this works (1)
+[One specific tier design choice + reasoning]
+
+## Why this works (2)
+[A second specific tier design choice + reasoning]
+
+## Next Steps
+**Got it (exit ticket passes):** [connect to forward standard or upcoming lesson]
+**Almost there:** [targeted small-group or conferring move — specific gap to address]
+**Needs re-teaching:** [specific reteach strategy or Tier 2/3 flag if gap is persistent]
+
+```
+
+### Document content — worksheets (`id: worksheet_group_a` / `worksheet_group_b` / `worksheet_group_c`)
+
+No teacher notes, look-fors, or rationale. All three include: vocabulary glossary + sentence
+frames + the "If you finish early" anchor task + open-ended reflective prompt (rubric O5 —
+UDL across all tiers) — all pulled from `shared` so they are identical across tiers by
+construction. The outline below defines each worksheet document's `sections`:
+
+```markdown
+# [Group A / Group B / Group C] — [Lesson Title]
+
+**Name:** _________________ **Date:** _________
+
+## Vocabulary
+[`from_shared: vocabulary` — the renderer formats the term–meaning pairs itself; never type a pipe-character table into a `text` field]
+
+**You can use these sentence supports:**
+- "I know ____ and ____. The part I don't know is ____."
+- "My strategy was ______ because ______."
+
+---
+
+[Problems pulled ONE AT A TIME, each with its scaffold directly above it — per problem N:
+at most ONE scaffold block (Below only, "For Problem N — ...", per R4/R7 fade), then
+`{"type": "from_shared", "key": "tN", "label": "N"} followed by a workspace block`. Problem text identical on all
+three tiers; never re-typed. Work space after each problem is automatic — do not add
+answer boxes for problems.]
+[Tier-only add-ons (e.g. Above "Go further" extension) as their own headed sections]
+
+---
+
+## If you finish early
+[`from_shared: anchor_activity` — identical block on all three tiers]
+
+## Reflect
+[`from_shared: reflect_prompt` — identical question on all three tiers]
+```
+
+---
+
+## Writing differentiation.json — math mapping
+
+- `shared.subject`: `"Mathematics"`
+- `shared.anchor_task`: the shared problem context / hook
+- `shared.t1`..`tN`: the core problem set shared by ALL tiers, one task per key — faceted {teacher: "the difficulty and what to watch for, as a plain sentence", student: <the problem>}
+- Teacher document: differentiation plan, max 3 pages; worksheets max 2 pages each
+- **Copyright:** do NOT reproduce Illustrative Mathematics (IM) student-facing text verbatim — problem contexts, activity narratives, and cool-down prompts from IM materials must be rewritten as original content.

--- a/skill-library/k12-lesson-differentiation/references/science.md
+++ b/skill-library/k12-lesson-differentiation/references/science.md
@@ -1,0 +1,362 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Science — differentiation pedagogy
+
+Loaded by `k12-lesson-differentiation` when the subject is **science**.
+
+## Identify the source lesson
+
+Three scenarios — detect which applies:
+
+**Scenario A — Source lesson exists in the prior conversation**
+If a lesson was produced or discussed earlier in this conversation, use it directly. Do NOT re-ask the teacher to share it.
+
+**Scenario B — Teacher uploads a source lesson**
+Read the file first. Confirm: grade level, Performance Expectation (PE), anchoring phenomenon, lesson structure and phases, which SEP(s) and CCC(s) are foregrounded. If the file is unreadable on first attempt, surface the error clearly and ask the teacher to re-share. Do NOT silently fabricate a lesson.
+
+**Scenario B2 — Teacher links a source lesson by URL**
+Fetch the URL and read its content first. Then confirm grade level, Performance Expectation (PE), anchoring phenomenon, lesson structure and phases, and foregrounded SEP(s)/CCC(s) exactly as in Scenario B. If the fetch fails or returns unusable content, surface the error clearly and ask the teacher to paste the lesson text or upload the file. Do NOT silently fabricate a lesson.
+
+**Fetching the lesson completes Step 1 only — it does NOT replace standards grounding.** Continue to Step 2 — Ground in standards. Skipping Step 2 after a URL fetch is the same critical failure as skipping it for an uploaded lesson.
+
+**Scenario C — No source lesson present**
+Ask before proceeding:
+> "Happy to differentiate. Do you have a specific lesson in mind? You can paste it, share a file, or tell me the grade + topic + standard and I'll work from that."
+
+**Detect OpenSciEd use.** OpenSciEd is confirmed when either:
+1. The teacher explicitly says so: "OpenSciEd," "OSE," "we use OpenSciEd"
+2. The uploaded source lesson contains OSE structural markers:
+   - Driving Question Board (DQB) references
+   - Scientists Circle or consensus model activities
+   - "What are we figuring out?" framing in the objective
+
+**Teacher's explicit statement wins over signal from provided lesson.** If the teacher says "I use
+OpenSciEd" and the provided lesson has any curriculum branding, treat as OSE-confirmed.
+
+---
+
+## Standards grounding
+
+Follow **Step 2 — Ground in standards** in SKILL.md: if the Learning Commons Knowledge Graph
+is connected, use the Science section of `references/learning-commons-kg.md`; if not,
+proceed from best knowledge and add the disclaimer footer to the teacher plan.
+
+**State-aware standards:** When state is known from Step 0, pass relevant jurisdiction in KG call.
+
+
+## The differentiation rules
+
+Apply all eight rules to every differentiated lesson.
+
+### R1 — Output structure
+
+**1 integrated teacher-facing lesson plan + 3 pure student-ready worksheets. NEVER 3 separate per-level lesson plans.**
+
+The lesson plan is a single document the teacher can use instead of (or alongside) the source lesson. Organized by lesson phase. Phases where all students work together (Launch Phenomenon, Sensemaking Discussion, Synthesis) are written once. Phases where students work independently (Investigation, explanation/CER task) show all three tiers in stacked labeled blocks.
+
+Do not produce 3 documents that each mix teacher notes and student tasks.
+
+### R2 — Three-dimensional scope preservation
+
+**Every tier addresses the original PE. Every SEP, CCC, and DCI element must appear in all tiers — including the hard cases.**
+
+For states other than Texas, all three NGSS dimensions are non-negotiable:
+- **SEP**: the same foregrounded practice(s) appear in every tier's task (e.g., if the lesson foregrounds "Constructing Explanations," every tier constructs an explanation)
+- **CCC**: the same crosscutting concept lens is applied in every tier
+- **DCI**: the same disciplinary core idea is the content target for all tiers
+
+Reducing cognitive scope for below-level students — removing a dimension, replacing investigation with a reading, or simplifying the phenomenon — is not differentiation.
+
+**Engagement must be preserved at the Below tier.** Do not give At/Above tiers interesting open-ended investigations and give Below tier a structured worksheet while others do science. All tiers investigate the same phenomenon — with different supports, not different tasks.
+
+### R3 — Teach up via the Observation → Representation → Explanation progression
+
+**Below-level scaffolds route students UP to grade-level explanation, not around it. Not "just simpler tasks."**
+
+| Tier | Entry point in the O→R→E progression |
+|---|---|
+| Below | Observation → Representation (structured, with supports), then into Explanation with scaffolded CER frame |
+| At | Representation → Explanation (standard CER) |
+| Above | Explanation → Extension (generalization, counter-phenomenon, quantification, engineering application) |
+
+**Below-level scaffolds must:**
+- Help students access and make sense of their observations (structured observation prompts, annotated diagrams)
+- Provide a scaffold for moving from observation to a data representation (guided data table, partial model template to populate)
+- Support construction of a CER with a sentence support — NOT provide the explanation itself
+
+**The sensemaking conflict is non-negotiable.** Do not smooth over the cognitive conflict between prior conception and observation for below-level students — help them name it: *"I thought ____ but I observed ____. Now I think ____."*
+
+**Identifying the conceptual prerequisite:**
+Use the DCI code from the PE. NGSS DCI progressions are explicit — the same core idea appears at K–2, 3–5, 6–8, and 9–12 at increasing sophistication. Identify what conceptual model students at the prior grade band built for this DCI and use that as the below-level scaffold's bridge. Name it in the Three-Dimensional Map as the prerequisite. This is typically a within- or adjacent-grade-band conceptual dependency, not a cascading cross-grade chain.
+
+- ✓ "Below-level uses [prior grade band's model of energy transfer]; students apply that representation to explain the new phenomenon."
+- ✗ "Below-level gets an easier version of the investigation."
+
+### R4 — Below-level scaffolds
+
+**The goal is to preserve productive struggle through sensemaking, not eliminate it. Scaffolds support students through the inquiry, not around it. NEVER route below-level students away from the investigation.**
+
+Failure modes to avoid:
+
+- ❌ Pre-telling the explanation before students investigate.
+- ❌ Removing investigation for below-level students — giving them a reading or video while other students investigate.
+- ❌ Simplifying the phenomenon — all tiers observe the same phenomenon.
+- ❌ Keyword strategies: "Look for the word 'heat' — that means energy transfer."
+- ❌ Answer-revealing support stations.
+- ❌ Literacy-only scaffolding as a substitute for science practice scaffolding.
+
+Acceptable scaffolds:
+
+- ✓ **Guiding/analysis questions** that sequence observation → connection → meaning: *"What changed? What stayed the same? What do you think caused that?"*
+- ✓ **Sentence supports for CER**: *"I claim ____. My evidence is ____. This supports my claim because ____."*
+- ✓ **Partial model templates** — a structured diagram students populate, not a completed diagram they label.
+- ✓ **Vocabulary support** — word banks or brief glossaries at the top of the task (header-level). Include everyday-language definition.
+- ✓ **Structured observation sheet** with explicit prompts (*"Draw what you see. Label any changes. Circle anything unexpected."*)
+- ✓ **Guided data table** with column headers and units pre-filled — students fill in observations, not the interpretation.
+- ✓ **Prior knowledge activation** — *"Remember when we figured out [prior concept]? How might that help explain what you're seeing now?"*
+
+#### Scaffold density cap
+
+**Cap embedded scaffolds at 1–2 per task. DO NOT EXCEED.**
+
+| Type | Counts toward cap? |
+|---|:-:|
+| Embedded — printed on every problem or task (organizer, sentence support, hint text) | YES |
+| Header-level features — vocabulary box, CER frame at top of worksheet | NO |
+| Teacher-side tools — support stations available on request, conferring prompts | NO |
+
+Pick a primary scaffold first. Only add a second if it contributes a genuinely different mode. If the second covers the same cognitive ground, drop it.
+
+### R5 — Required pedagogical infrastructure
+
+**Every differentiated science lesson must include all five. Embedded inline within the lesson plan.**
+
+| Element | What it is | Where in lesson plan |
+|---|---|---|
+| **Formative check** | Concrete mid-lesson or end-of-lesson prompt — exit ticket or CER check. Not "circulate and observe." | Inline in the phase where it occurs |
+| **Anchor activity** | A standard-aligned extension for early finishers. Not busywork — must require the foregrounded SEP. Written student-facing in `shared.anchor_activity` and printed on every worksheet — an anchor activity that exists only as a plan description is a failure. | End of lesson plan + all three worksheets |
+| **Flexible-grouping language** | Tier assignments tied to THIS lesson's evidence; revisable during lesson based on the formative check. | Compact callout box in lesson header |
+| **Per-level misconception notes** | Common science misconceptions at each level + teacher conferring move + signal for small group. | Inline callout within each tiered activity block — max 2 sentences per level |
+| **Sensemaking conflict prompt** | A prompt that explicitly surfaces the tension between prior conception and observation. | Embedded in the Investigation or CER task |
+
+**If OSE-confirmed, three additional elements are non-negotiable across all tiers:**
+- **Consensus model** — all tiers contribute to and revise the class consensus model. Below: partial model template. At: blank model. Above: extend the model to account for an additional case.
+- **Driving question board** — all tiers add to and reference the DQB.
+- **CER structure** — consistent across tiers; only the frame support differs (Below: sentence support. At: prompt only. Above: counter-argument + rebuttal added.)
+
+In addition: **each student worksheet ends with one reflective prompt, present on all three tiers:** *"What are you still wondering about?"* Store it as `shared.reflect_prompt` and name it in each tier's **Worksheet tasks** line in the lesson plan — a printed task the plan never mentions is a failure.
+
+### R6 — Invisible modifications
+
+**Same phenomenon, same investigation, same core explanation task across levels. Only the supports differ.**
+
+All tiers observe the same phenomenon. All tiers investigate with the same materials and procedure. In the integrated lesson plan, the shared investigation and phenomenon appear once under "ALL STUDENTS." The tier blocks show only what differs — scaffolds, conferring prompts, extension.
+
+Do not restate the full investigation text in every tier block — reference it and describe only what differs.
+
+**Do not announce scaffold removals to students.** If a structured observation sheet is used in Task 1 but not Task 3, its absence is silent — no label, aside, or comment (e.g., no "(No template this time)" or "Try it without the frame"). The scaffold simply does not appear; students encounter the task on its own terms.
+
+Numbers, data sets, and material quantities should be identical across tiers by default. May be adjusted for Below only if the investigative structure is fully preserved.
+
+### R7 — Within-level progressive scaffolding
+
+**Each level's worksheet sequences tasks with progressive cognitive demand.**
+
+#### Below-level fade pattern
+
+| Task | Embedded scaffolds | Pattern |
+|---|:-:|---|
+| Observation task | Up to 2 | Structured |
+| Representation task | Up to 1 | Guided |
+| CER task | 0–1 embedded (frame at header level OK) | Productive struggle |
+| Reflection prompt | 0 | Independent |
+
+#### Above-level extension quality test
+
+Every above-level extension must answer: **what new thinking does this require that the at-level student isn't already doing?**
+
+A real extension requires at least one of:
+- **Engineering application**: design a solution using the science concept
+- **Counter-phenomenon or anomalous case**: a situation where the phenomenon behaves differently, requiring generalization
+- **Quantification**: connect the qualitative explanation to a mathematical relationship (grades 3+)
+- **Forward PE preview**: the next NGSS PE in the DCI progression — conceptual element, not just vocabulary
+- **Scientific argumentation**: evaluate a competing explanation, find evidence to challenge their own claim, or write a rebuttal
+- **Societal/ethical dimension**: how does this phenomenon connect to a real-world problem or decision? (grades 6–12)
+
+Reject if: more of the same investigation, a longer worksheet, or a notation swap only.
+
+### R8 — Scope and defaults
+
+**If tier scope is not specified, ask ONE combined question before generating:**
+
+> "I'll differentiate this into below / at / above grade-level tiers — are those the right three? And any specific learner needs I should know about (ELL levels, IEP goal areas)? If not, I'll apply UDL defaults (sentence supports and vocabulary support across all tiers)."
+
+If scope is already specified, apply defaults silently and proceed.
+
+**Defaults applied silently when not specified:**
+- Tiers: below / at / above
+- UDL features: CER sentence supports and vocabulary glossary in **all three** student worksheets (not Below only — rubric O5)
+- Scope: full lesson (all phases + exit ticket / CER task)
+- OSE structure: applied if OSE-confirmed; not applied otherwise
+
+**When no formative assessment data is available**, default to this below-level profile:
+- Has observational access to the phenomenon but cannot yet name the mechanism — perceptual access without explanatory language
+- Likely holds at least one common misconception for this DCI; the sensemaking conflict frame (*"I thought ____ but I observed ____"*) is the primary scaffold
+- Can produce an observation but needs structure to connect it to a model or CER independently
+- The proximate conceptual prerequisite (identified per R3) may not be secure
+
+Design default below-level scaffolding accordingly: structured observation prompts → misconception-surfacing sentence support → CER frame. Do not pre-scaffold the explanation content.
+
+If the inferred gap is wider than one within-band conceptual step, add a flag to the Next Steps block that Tier 2/3 support may be needed beyond lesson-level differentiation.
+
+After generating the default tiered plan, prompt the teacher: *"Do you have any notes from the last lesson — observation notes, CER samples, or exit ticket results — that could tell me which misconception is active, or whether students could access the phenomenon but struggled to explain it?"* This can replace the assumed misconception with a confirmed one and clarify whether students are stuck at the observation→representation step or the representation→explanation step, shifting where the scaffold focuses. FA data rarely inverts the default approach in science but meaningfully sharpens it.
+
+---
+
+### Document content — integrated lesson plan (`id: teacher_plan`) — max 5 pages
+
+Organized by phase. Reproduce the source lesson's phase structure (e.g., Launch Phenomenon → Investigation → Sensemaking Discussion → Explanation Task → Synthesis → Exit Ticket). Do not invent phases not present in the source.
+
+The outline below defines the content and order of this document's `sections`: each `##`
+heading becomes one section, its body becomes that section's blocks (use `from_shared` blocks
+for the PE, misconceptions, and exit ticket; `phase_header` blocks for phases; `labeled` blocks
+for the bold fields).
+
+**Length budget: ~2,000 words rendered (the 5-page cap in practice).** Tighten the phase and
+tier sections before touching the closers (Why this works, Next Steps) — the most common
+overrun is a Worksheet tasks line that restates worksheet content instead of naming it.
+**"Why this works (1)" and "Why this works (2)" are required and cannot be dropped to meet the
+length budget — cut phase or tier section prose first.**
+
+```markdown
+# Differentiated Lesson Plan: [Lesson Title]
+
+**PE:** [verbatim]  **Grade:** [X]  **Duration:** [X min]
+**Anchoring Phenomenon:** [one sentence]
+*Learner needs: [If no specific needs were provided: "UDL defaults applied — CER sentence supports and vocabulary support across all tiers." If learner needs were specified, describe them here instead.]*
+
+## Learning Objective
+[One statement covering all tiers. For OSE-confirmed: "Students will figure out [DCI element] by using [SEP] to make sense of [phenomenon]."]
+
+## Three-Dimensional Map
+- **SEP(s):** [name + ≤10-word gist — the PE is already quoted verbatim in the header]
+- **CCC(s):** [name + ≤10-word gist]
+- **DCI:** [brief]
+- **Conceptual prerequisite:** [code + ≤10-word gist] — grounds Below scaffolds
+- **Forward PE:** [code + ≤10-word gist] — grounds Above extension
+
+(Density rule applies: the PE appears verbatim exactly once, in the header. Never re-paste
+full standard text in this map — code + gist only.)
+
+## Tier Grouping
+[One bullet per tier, ≤15 words each: the placement signal for that tier.]
+[Then ONE sentence: evidence basis ("Based on prior CER exit ticket on [PE]" or "Default
+profile applied — no FA data available").]
+*Tier assignments are revisable — revisit after the formative check.*
+
+---
+
+## [Phase Name — whole class]
+[Teacher facilitation moves, key questions, what NOT to do. For OSE-confirmed: consensus model update move + DQB reference.]
+
+## [Phase Name — tiered activity]
+**ALL STUDENTS:** [shared setup — same phenomenon, same materials; ONE sentence]
+
+[ONE `table` block — never three labeled paragraph stacks. Columns: Below (Group A) / At (Group B) / Above (Group C).
+Two rows:
+- **Students do** — ≤25 words per cell, fragments not sentences: the task path and the
+  scaffolds in play (plus the extension prompt in the Above cell).
+- **Worksheet tasks** — ≤40 words per cell, written LAST: read that tier's FINAL worksheet
+  document's blocks top-to-bottom and name every printed task in order — investigation/CER
+  tasks by name with their printed scaffolds (e.g. "Observation sheet (structured), CER
+  paragraph (frame)"), every tier-only add-on or extension sub-part by its printed heading,
+  exit ticket, "If you finish early" anchor task, Reflect prompt. List items; don't restate
+  their text. Name nothing unprinted — no "on request" supports, no planned organizer the
+  worksheet dropped. Never copy another tier's cell.]
+
+[Then ONE `callout` (note style): misconception watch + conferring move — one sentence per
+tier that needs one, ≤2 sentences per level. Never bury these inside the table cells or a
+paragraph.]
+
+## Formative Check
+[Two required elements:
+1. **Mid-lesson checkpoint:** A specific check during the investigation or sense-making phase — name the trigger or artifact (e.g., "After the observation table is complete, scan three notebooks: if students are describing observations without connecting to the phenomenon, pause and use the CCC prompt before the CER task"). 'Circulate and observe' does not pass.
+2. **Exit ticket with explicit sort criteria:** State what a student must produce or demonstrate for THIS lesson's PE, e.g.: "Got it — [e.g., writes a CER that names the specific mechanism and cites data from the investigation] / Almost there — [e.g., claim and evidence present but reasoning does not connect to the DCI] / Needs re-teaching — [e.g., cannot state a claim from the data without prompting]." Generic bucket labels without lesson-specific criteria do not pass.]
+
+## Anchor Activity
+[`from_shared: anchor_activity` — the same student-facing task printed on every worksheet — plus one teacher-only line: when to deploy it; must require the foregrounded SEP]
+
+## Why this works (1)
+[One specific tier design choice + reasoning]
+
+## Why this works (2)
+[A second specific tier design choice + reasoning]
+
+## Next Steps
+**Got it (exit ticket passes):** [connect to forward standard or upcoming lesson]
+**Almost there:** [targeted small-group or conferring move — specific gap to address]
+**Needs re-teaching:** [specific reteach strategy or Tier 2/3 flag if gap is persistent]
+
+```
+
+### Document content — worksheets (`id: worksheet_group_a` / `worksheet_group_b` / `worksheet_group_c`)
+
+No teacher notes, look-fors, or rationale in any worksheet. Vocabulary, CER sentence supports,
+the "If you finish early" anchor task, and the reflective prompt are pulled from `shared` so
+they are identical across tiers by construction.
+
+On the printed page, never label anything "CER" or "sensemaking" — those are teacher terms
+(see SKILL.md, Student-facing language). Organizer labels read *Claim / Evidence /
+Reasoning*; the sensemaking frame is introduced as *"Check your thinking"*.
+
+| Level | Worksheet features |
+|---|---|
+| Below | Same phenomenon and investigation as At. Scaffolds embedded per R4 with fade pattern per R7. Structured observation sheet, partial model template, CER sentence support at header level. |
+| At | Source worksheet preserved or lightly reformatted. Standard CER prompt. |
+| Above | Same investigation + extension prompt per R7. CER + counter-argument / rebuttal prompt. |
+
+```markdown
+# [Group A / Group B / Group C] — [Lesson Title]
+
+**Name:** _________________ **Date:** _________
+
+## Vocabulary
+[`from_shared: vocabulary` — the renderer formats the term–meaning pairs itself; never type a pipe-character table into a `text` field]
+
+**You can use these sentence supports:**
+- "I claim ____. My evidence is ____. This supports my claim because ____."
+- "I thought ____ but I observed ____. Now I think ____."
+
+---
+
+[Tasks pulled ONE AT A TIME, each with its scaffold directly above it — per task N: at most
+ONE scaffold block (Below only, "For Task N — ...", per R4/R7 fade), then
+`{"type": "from_shared", "key": "tN", "label": "N"} followed by a workspace block`. Investigation/CER task text
+identical on all three tiers; never re-typed. Writing space after each task is automatic —
+do not add answer boxes for tasks.]
+[Tier-only add-ons (e.g. Above "Go further" extension) as their own headed sections]
+
+---
+
+## If you finish early
+[`from_shared: anchor_activity` — identical block on all three tiers]
+
+## Reflect
+[`from_shared: reflect_prompt` — "What are you still wondering about?"]
+```
+
+---
+
+## Writing differentiation.json — science mapping
+
+- `shared.subject`: `"Science"`
+- `shared.standard_code` / `shared.standard_text`: the Performance Expectation, verbatim
+- `shared.anchor_task`: the anchoring phenomenon
+- `shared.t1`..`tN`: the investigation and CER tasks shared by ALL tiers, one task per key — faceted {teacher: "the difficulty and what to watch for, as a plain sentence", student: <the task>}
+- `shared.sentence_frames`: CER frames as plain text with blanks sized for handwriting, placed with the task's writing space
+- Teacher document: **integrated differentiated lesson plan** (organized by phase), max 5 pages; worksheets max 2 pages each
+- **Copyright:** do NOT reproduce OpenSciEd (OSE) student-facing text verbatim — this applies to investigation instructions, phenomenon descriptions, and CER prompts drawn from OSE materials.

--- a/skill-library/k12-lesson-differentiation/references/social_studies.md
+++ b/skill-library/k12-lesson-differentiation/references/social_studies.md
@@ -1,0 +1,331 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Social Studies — differentiation pedagogy
+
+Loaded by `k12-lesson-differentiation` when the subject is **social studies**.
+
+## Identify the source lesson
+
+**State identification.** Social studies standards are state-specific. If the teacher names a state (or one is established earlier in the conversation), anchor to it: use the state-specific standards framework (e.g., California HSS Framework, Texas TEKS, New York Passport to Social Studies) as the primary content scope reference. If the teacher does not name a state and it is not inferrable, ask.
+
+**C3 Framework note.** The C3 Framework is an *inquiry design* framework, not a standards document. Use C3 for instructional design principles (inquiry arc, sourcing, argumentation, civic action) but defer to state standards for what students must know and be able to do. If the teacher references C3 directly, use its inquiry arc to structure the lesson's tasks — but anchor content scope to the state standard.
+
+Then detect which scenario applies:
+
+**Scenario A — Source lesson exists in the prior conversation**
+If a lesson was produced or discussed earlier in this conversation, use it directly. Do NOT re-ask the teacher to share it.
+
+
+**Scenario B — Teacher uploads a source lesson**
+Read the file first. Confirm: grade level, subject (history / civics / geography / economics),
+standard, learning objective, lesson structure. **Also extract the state** from the standard
+code if present (TEKS 113.xx → Texas; California HSS/CCSS → California; MA Curriculum
+Framework → Massachusetts; etc.). Store as state — do not ask the teacher if it can be
+inferred from the standard code.
+
+
+**Scenario B2 — Teacher links a source lesson by URL**
+Fetch the URL and read its content first. Then confirm grade level, subject (history / civics / geography / economics), standard, learning objective, and lesson structure exactly as in Scenario B. If the fetch fails or returns unusable content, surface the error clearly and ask the teacher to paste the lesson text or upload the file. Do NOT silently fabricate a lesson.
+
+**Fetching the lesson completes Step 1 only — it does NOT replace standards grounding.** Continue to Step 2 — Ground in standards. Skipping Step 2 after a URL fetch is the same critical failure as skipping it for an uploaded lesson.
+
+**Scenario C — No source lesson present**
+Ask before proceeding (include state if state is also unknown):
+> "Happy to differentiate. Do you have a specific lesson in mind? You can paste it, share a file, or tell me the grade + topic + standard and I'll work from that."
+
+---
+
+## Standards grounding
+
+Follow **Step 2 — Ground in standards** in SKILL.md: if the Learning Commons Knowledge Graph
+is connected, use the Social Studies section of `references/learning-commons-kg.md`; if not,
+proceed from best knowledge and add the disclaimer footer to the teacher plan.
+
+## The differentiation rules
+
+Apply all eight rules to every differentiated lesson.
+
+### R1 — Output structure
+
+**1 cohesive teacher-facing differentiation plan + 3 pure student-ready worksheets. NEVER 3 hybrid per-level lesson plans.**
+
+The hybrid pattern — 3 per-level documents each mixing teacher notes and student content — is a specific failure mode. The teacher plan covers all levels in one document; the worksheets are student-only.
+
+### R2 — Standard scope preservation
+
+**Every level addresses the original standard. Every standard element stays in play across all levels — including the hard cases.**
+
+The standard's hardest cognitive demand is exactly what below-level students most need to encounter with scaffolds, not the element to drop. Common failure modes:
+- ❌ Replacing a corroboration task (compare two sources) with a single-source task for below-level students — not differentiation, just a different assignment.
+- ❌ Removing the essential question from below-level work.
+- ❌ Replacing argumentation with identification for below-level students.
+
+**Engagement must be preserved at the Below tier.** Do not assign rich primary sources or compelling essential questions to At/Above and worksheet drills to Below. All tiers engage the same essential question and source context — with different supports, not different tasks.
+
+### R3 — Teach-up via prerequisites
+
+**Below-level scaffolds route students UP to grade-level work, grounded in the two default SS prerequisites. Not "just easier."**
+
+- ✓ "Below-level uses a guided annotation frame (SOAPS) scaffolding the sourcing routine; students apply it to the same grade-level source task."
+- ✗ "Below-level uses a shorter text / simpler vocabulary / fewer sources."
+
+**The two SS prerequisites.** Unlike math, the KG does not provide explicit prerequisite mappings for social studies standards. The two prerequisites that apply to nearly every SS lesson are stable defaults:
+
+1. **Content vocabulary.** The specific terms needed to access the lesson's sources and tasks are the primary gate. Extract the 4–6 key terms from the lesson's source material itself — these become the word bank. Vocabulary is a prerequisite gate, not just a UDL feature; it belongs here even though R8 also requires it as a UDL default across all tiers.
+
+2. **Sourcing as a taught routine.** Sourcing (who produced this, why, and under what conditions?) is the foundational disciplinary skill — the prerequisite for contextualization and corroboration. Treat it as a *taught routine*, not an assumed capacity. Disciplinary thinking skills do not follow a strict grade-level progression; the question is whether the routine has been explicitly taught, not which grade introduced it. Default to a guided annotation frame (SOAPS or HAPP) as the primary below-level scaffold unless the teacher confirms sourcing is established practice in the class.
+
+When the teacher confirms sourcing is established, shift the below-level scaffold toward contextualization support. When the lesson targets corroboration, treat sourcing + contextualization as the prerequisite baseline and scaffold from there.
+
+#### Source complexity entry point
+
+| Tier | Entry point |
+|---|---|
+| Below | Concrete / Visual — photograph, map, artifact, or heavily annotated short excerpt; 1 source; scaffolded analysis frame |
+| At | Representational / Textual — leveled text or lightly annotated primary source; 1–2 sources; structured questions |
+| Above | Abstract / Argumentative — full primary source(s) or complex secondary text; 2–3 sources; open synthesis or argument task |
+
+### R4 — Below-level scaffolds
+
+**The goal is to preserve productive struggle, not eliminate it — scaffolds support thinking without revealing answers or collapsing the historical/civic reasoning the standard requires.**
+
+Failure modes to avoid:
+
+- ❌ Single-cause simplification: reducing complex historical causation to one factor for below-level students. Oversimplification is not a scaffold — it undermines the disciplinary thinking the standard requires.
+- ❌ Answer-embedded questions: framing questions so the historical interpretation is revealed in the question itself.
+- ❌ Fill-in-the-blank narratives where students only insert pre-given facts.
+- ❌ Presentism framing: simplifying historical context by using modern values without scaffolding historical context.
+- ❌ Multiple-choice sourcing when the standard requires open analysis or argument.
+
+Acceptable scaffolds:
+
+- ✓ Sentence supports for historical/civic analysis: "This source shows ___ because ___. This matters because ___."
+- ✓ Guided annotation frames (e.g., SOAPS: Source, Occasion, Audience, Purpose, Subject; or HAPP: Historical context, Audience, Purpose, Point of view) — pre-structured with prompts, not pre-filled answers.
+- ✓ Tiered texts: same topic and essential question, different reading complexity. Same questions across all tiers.
+- ✓ Visual primary sources (photographs, maps, political cartoons) as concrete entry points before transitioning to text-based sources.
+- ✓ Word banks for discipline-specific vocabulary (not for choosing the argument or answer). Note: word banks appear on all tiers by default per R8 UDL — do not restrict them to Below only.
+- ✓ Graphic organizers matched to the thinking type (see table below).
+- ✓ Reduced source set with an explicit transfer step: "Analyze this one source first, then apply the same thinking to the second source."
+
+#### Concept → primary scaffold
+
+| Social studies thinking type | Primary scaffold |
+|---|---|
+| Chronological reasoning / sequence | Annotated timeline or cause-effect chain organizer |
+| Primary source analysis | Guided annotation frame (SOAPS or HAPP) |
+| Geographic / spatial reasoning | Labeled map with structured guiding questions |
+| Civic argument / claim-based reasoning | CER (Claim-Evidence-Reasoning) frame |
+| Economic decision-making / trade-offs | Cost-benefit or scarcity organizer |
+| Multiple perspectives / point of view | Two-column perspective organizer |
+| Comparative / synthesis | T-chart or evidence synthesis matrix |
+
+Pick the **primary scaffold** based on the disciplinary thinking type, not the grade level. If the thinking type spans categories, pick the scaffold for the harder lift for below-level students.
+
+The test: does the scaffold leave the disciplinary thinking to the student, or does it perform that thinking for the student? If the latter, it is not a scaffold.
+
+#### Scaffold density cap
+
+**Cap embedded scaffolds at 1–2 per task. DO NOT EXCEED.**
+
+| Type | Counts toward cap? |
+|---|:-:|
+| Embedded — printed directly on the task (organizer, sentence support, annotation prompt) | YES |
+| Header-level features — vocabulary box, sentence supports at top of worksheet | NO |
+| Teacher-side tools — tiered texts available on request, conferring prompts | NO |
+
+**Pick a primary scaffold first.** Only add a second if it contributes a genuinely different mode. If the second asks the student to do the same cognitive work, drop it.
+
+### R5 — Required pedagogical infrastructure
+
+**Every differentiated lesson must include all four:**
+
+| Section | What it is | Where |
+|---|---|---|
+| **Formative check** | Concrete mid-lesson or end-of-lesson prompt to gauge readiness — a tiered exit ticket counts. Not "monitor students." | Teacher plan + per-level worksheet |
+| **Anchor activity** | Standard-aligned task for early finishers — e.g., an additional source to analyze, a "so what?" extension question, or a connection to a current event. Not busywork. Written student-facing in `shared.anchor_activity` and printed on every worksheet — an anchor activity that exists only as a plan description is a failure. | Teacher plan + all three worksheets |
+| **Flexible-grouping language** | Tier assignments tied to THIS lesson's evidence, explicitly revisable based on what the formative check reveals. Not static ability tracks. | Teacher plan |
+| **Per-level misconception notes** | Common disciplinary errors specific to each level + teacher prompt + signal for pulling a small group. KG-sourced when available, drafted otherwise. | Teacher plan |
+
+In addition: **each student worksheet ends with one open-ended or reflective prompt, present on all three tiers** — e.g., "What questions does this source raise for you?", "Whose perspective is missing from these sources?", "How does this connect to something happening today?" This is not optional for any tier. Store it as `shared.reflect_prompt` and name it in each tier's **Worksheet tasks** line in the teacher plan — a printed task the plan never mentions is a failure.
+
+### R6 — Invisible modifications
+
+**Same essential question / same source context / same core task across levels where pedagogically possible. Only the supports differ.**
+
+What can differ: reading complexity of the text provided; scaffolds on the worksheet; optional teacher-provided supports during conferring; the extension or reflection prompt.
+
+What should NOT differ: the essential question being investigated; the type of disciplinary thinking required (do not downgrade the thinking type for below-level); the historical/geographic/civic phenomenon under study.
+
+**Do not announce scaffold removals to students.** If a scaffold appears in Task 1 but not Task 3, its absence is silent — no label, aside, or comment (e.g., no "(No annotation frame this time)" or "Try it without the organizer"). The scaffold simply does not appear; students encounter the task on its own terms.
+
+Use the same primary source(s) across tiers by default. Source complexity may be adjusted for Below (e.g., an annotated excerpt vs. the full document) only if the core analytical task is fully preserved.
+
+### R7 — Within-level progressive scaffolding
+
+**Each level's worksheet sequences tasks with progressive cognitive demand.**
+
+#### Below-level fade pattern
+
+| Task | Embedded scaffolds | Pattern |
+|---|:-:|---|
+| Task 1 | Up to 2 | Scaffolded |
+| Task 2 | Up to 1 | Guided |
+| Task 3+ | 0 embedded | Independent |
+| Exit ticket | 0–1 | Mastery check |
+
+The goal is a true fade (2 → 1 → 0), not cosmetic variation across uniformly-dense tasks.
+
+#### Above-level extension quality test
+
+Every above-level extension must answer: **what new disciplinary thinking does this require that the at-level student isn't already doing?**
+
+A real extension requires at least one of:
+
+| Type | What it requires |
+|---|---|
+| New cognitive operation | At-level sources/describes; above-level corroborates, evaluates, or constructs an argument. (Bloom / Webb DOK shift.) |
+| Historiographic or disciplinary insight | Surfaces a scholarly debate, interpretive tension, or methodological question — not just "what happened" but "how do we know." |
+| Forward-standard preview | A real analytical demand from the forward-progression standard — not just its vocabulary. |
+| Open generative task | Student produces something new: historical argument, counterargument, civic proposal, map with a claim. |
+
+Reject if: more sources covering the same argument, notation or vocabulary swap only, or restatement.
+
+### R8 — Scope and defaults
+
+**If tier scope is not specified, ask ONE combined question before generating:**
+
+> "I'll differentiate this into below / at / above grade-level tiers — are those the right three? And any specific learner needs I should know about (ELL students, IEP accommodations, reading levels)? If not, I'll apply UDL defaults (sentence stems and vocabulary support across all tiers)."
+
+If scope is already specified, apply defaults silently and proceed.
+
+**Defaults applied silently when not specified:**
+- Tiers: below / at / above
+- UDL features: sentence stems and vocabulary glossary in **all three** student worksheets (not Below only — rubric O5)
+- Scope: full lesson (all phases + exit ticket)
+- Number of levels: 3
+- **Tier profiles (no FA data):** Below — content vocabulary gaps likely; sourcing routine not yet internalized; scaffold with guided annotation frame + word bank. At — core vocabulary mostly in place; applies sourcing and contextualization with prompting. Above — handles grade-level text independently; applies sourcing and contextualization with some independence; ready for corroboration or multi-source tasks.
+- **FA follow-up prompt.** After generating the default tiered plan, ask: *"Do you have any recent signals about where students are — a vocabulary check, a prior sourcing task, or exit ticket results?"* Social studies FA data mainly helps confirm which of the two default barriers (vocabulary vs. sourcing routine) to weight more heavily — it rarely changes the scaffold type entirely. Treat this as a useful refinement, not a required input.
+
+---
+
+### Document content — teacher plan (`id: teacher_plan`) — max 3 pages
+
+**Length budget: ~1,200 words rendered (the 3-page cap in practice).** Tighten the tier
+sections and overview before touching the closers (Flexible Grouping, Why this works, Next
+Steps) — the most common overrun is a Worksheet tasks line that restates worksheet content
+instead of naming it. **"Why this works (1)" and "Why this works (2)" are required and cannot
+be dropped to meet the length budget — cut tier section prose first.**
+
+The outline below defines the content and order of the teacher plan document's `sections`:
+each `##` heading becomes one section, its body becomes that section's blocks (use
+`from_shared` blocks for the standard, misconceptions, and exit ticket; `labeled` blocks for
+the bold fields).
+
+```markdown
+# Differentiation Plan: [Lesson Title]
+
+**Standard:** [verbatim]  **Grade:** [X]  **State:** [X]  **Duration:** [X min]  **Discipline:** [history / civics / geography / economics]
+*Learner needs: [If no specific needs were provided: "UDL defaults applied — sentence supports and vocabulary support across all tiers." If learner needs were specified, describe them here instead.]*
+
+## Learning Objective
+[Same objective across all tiers — preserved from source lesson]
+
+## Differentiation Overview
+[1 short paragraph, ≤3 sentences: approach, source complexity entry point, primary scaffold
+type, essential question preserved across tiers. Standards by code + ≤10-word gist — the
+target standard is already verbatim in the header.]
+
+## Tier Design
+[ONE `table` block — never three labeled paragraph stacks. Columns: Below (Group A) / At (Group B) / Above (Group C).
+Rows (a cell may be "—" where a field doesn't apply to that tier):
+- **Entry point / grounding** — Below: the 4–6 key vocabulary terms addressed + sourcing
+  routine status (scaffolded via [annotation frame type] or established). Above: forward
+  standard by code + ≤10-word gist from [state] vertical alignment. At: "—".
+- **Scaffolds / extension** — fragments, ≤25 words per cell: Below scaffolds in play; At
+  supports; Above extension + which R7 quality type it meets.
+- **Conferring move** — one specific prompt per tier.
+- **Worksheet tasks** — ≤40 words per cell, written LAST: read that tier's FINAL worksheet
+  document's blocks top-to-bottom and name every printed task in order — tasks by name with
+  their printed scaffolds (e.g. "Source A read (annotation guide), Sourcing organizer, Claim
+  paragraph"), every tier-only add-on or extension sub-part by its printed heading, exit
+  ticket, "If you finish early" anchor task, Reflect prompt. List items; don't restate their
+  text. Name nothing unprinted — no "on request" supports, no planned organizer the
+  worksheet dropped. Never copy another tier's cell.]
+
+[Then ONE `callout` (note style): misconception watch — pattern + teacher prompt, ≤2
+sentences per tier that needs one.]
+
+## Formative Check
+[Two required elements:
+1. **Mid-lesson checkpoint:** A specific check during sourcing or analysis work — name the trigger or artifact (e.g., "After students complete the sourcing organizer, collect and scan: if fewer than half identified the author's purpose, pause and model the HAPP frame with a think-aloud before the claim paragraph"). 'Circulate and observe' does not pass.
+2. **Exit ticket with explicit sort criteria:** State what a student must produce or demonstrate for THIS lesson's standard, e.g.: "Got it — [e.g., states a claim and cites two sources with sourcing reasoning] / Almost there — [e.g., states a claim and cites evidence but sourcing reasoning is missing or generic] / Needs re-teaching — [e.g., cannot state a claim independently or cites without attribution]." Generic bucket labels without lesson-specific criteria do not pass.]
+
+## Anchor Activity
+[`from_shared: anchor_activity` — the same student-facing task printed on every worksheet — plus one teacher-only line: when to deploy it and why it requires disciplinary reasoning]
+
+## Flexible Grouping
+[Current tier assignments, the evidence or basis for placement (e.g., "Placed based on prior sourcing task / exit ticket on [standard]" or "Default profile applied — no diagnostic data available"), and an explicit statement that groups are revisable after the formative check]
+
+## Why this works (1)
+[One specific tier design choice + reasoning]
+
+## Why this works (2)
+[A second specific tier design choice + reasoning]
+
+## Next Steps
+**Got it (exit ticket passes):** [connect to forward standard or upcoming lesson]
+**Almost there:** [targeted small-group or conferring move — specific gap to address]
+**Needs re-teaching:** [specific reteach strategy or Tier 2/3 flag if gap is persistent]
+
+```
+
+### Document content — worksheets (`id: worksheet_group_a` / `worksheet_group_b` / `worksheet_group_c`)
+
+No teacher notes, look-fors, or rationale in any worksheet. All three include: vocabulary
+glossary + sentence stems + the "If you finish early" anchor task + open-ended reflective
+prompt (rubric O5 — UDL across all tiers) — all pulled from `shared` so they are identical
+across tiers by construction.
+
+```markdown
+# [Group A / Group B / Group C] — [Lesson Title]
+
+**Name:** _________________ **Date:** _________
+
+## Vocabulary
+[`from_shared: vocabulary` — the renderer formats the term–meaning pairs itself; never type a pipe-character table into a `text` field]
+
+**You can use these sentence supports:**
+- "This source shows ___ because ___. This matters because ___."
+- "My strategy was ______ because ______."
+
+---
+
+[Tasks pulled ONE AT A TIME, each with its scaffold directly above it — per task N: at most
+ONE scaffold block (Below only, "For Task N — ...", per R4/R7 fade), then
+`{"type": "from_shared", "key": "tN", "label": "N"} followed by a workspace block`. Source-analysis task text
+identical on all three tiers; never re-typed. Writing space after each task is automatic —
+do not add answer boxes for tasks.]
+[Tier-only add-ons (e.g. Above "Go further" extension) as their own headed sections]
+
+---
+
+## If you finish early
+[`from_shared: anchor_activity` — identical block on all three tiers]
+
+## Reflect
+[`from_shared: reflect_prompt` — identical question on all three tiers]
+```
+
+---
+
+## Writing differentiation.json — social studies mapping
+
+- `shared.subject`: `"Social Studies"`
+- `shared.anchor_task`: the essential/compelling question
+- `shared.t1`..`tN`: the source analysis tasks shared by ALL tiers, one task per key — faceted {teacher: "the difficulty and what to watch for, as a plain sentence", student: <the task>}
+- Teacher document: differentiation plan, max 3 pages; worksheets max 2 pages each
+- **Copyright:** do NOT reproduce primary source text or curriculum source-set descriptions verbatim — provide citations and pointers only; student-facing analysis tasks must be original.

--- a/skill-library/k12-lesson-differentiation/scripts/lesson_common.py
+++ b/skill-library/k12-lesson-differentiation/scripts/lesson_common.py
@@ -1,0 +1,763 @@
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared-content helpers used by all artifact renderers.
+
+The material-source JSON has a `shared` block holding every piece of content that appears in more
+than one artifact (standard, anchor task, problems, exit ticket, look-fors, vocabulary,
+misconceptions, sentence supports). Renderers expand it via `expand_from_shared`, so shared
+content is written once and can never drift between artifacts.
+"""
+from __future__ import annotations
+
+import re
+
+# ---- render-time print-safety repair ---------------------------------------------------
+# Two failure classes survive prompt instructions and are repaired structurally instead:
+# (1) markdown pipe tables drawn inside prose fields print as literal '|' rows — convert
+#     them to real `table` blocks; (2) the ■ unknown-number symbol appearing in an artifact
+#     with no defining sentence in THAT artifact (look-fors carry ■ into the observation
+#     sheet via from_shared, where the model writes no prose) — append the skill's standard
+#     definition line to the first section that uses it.
+
+_PIPE_LINE = re.compile(r"[^|\n]*\|[^|\n]+\|")            # a line with >=2 pipe chars
+_SEP_LINE = re.compile(r"^\s*\|?[\s:|\-]+\|?\s*$")        # |---|:---| separator row
+UNKNOWN_SYMBOL = "■"
+_UNKNOWN_DEFINED = re.compile(
+    r"(use|using|write|stands for|symbol|means)[^.]{0,50}■"
+    r"|■[^.]{0,50}(for the|stands for|means|is the|if you need)", re.IGNORECASE)
+
+
+def _parse_pipe_rows(lines: list[str]) -> list[list[str]]:
+    rows = []
+    for ln in lines:
+        if _SEP_LINE.match(ln):
+            continue
+        rows.append([c.strip() for c in ln.strip().strip("|").split("|")])
+    width = max((len(r) for r in rows), default=0)
+    return [r + [""] * (width - len(r)) for r in rows]
+
+
+_INLINE_SEP = re.compile(r"\|\s*:?-{2,}")  # an inline |--- separator (table collapsed to one line)
+_BULLET_LINE = re.compile(r"^\s*(?:[•▪‣◦]|[-–])\s+")
+
+# Enumerated sub-parts written mid-prose — "… from Task 1: (a) Predict … (b) Describe …" —
+# read as a wall of text. Insert a line break before each "(a)"/"(1)" marker that follows
+# sentence-ending punctuation, so every sub-part starts on its own line. Both renderers
+# preserve single newlines as line breaks.
+_ENUM_MIDPROSE = re.compile(r"(?<=[.!?:;])[ \t]+(?=\((?:[a-h]|\d{1,2})\)\s)")
+
+# Standards bodies write sub-parts as "A. Describe ... B. Describe ..." mid-prose; a verbatim
+# standard then renders as a wall of text. Break before each capital-letter marker -- but only
+# when the text carries a real enumeration (both "A." and "B." present after sentence ends),
+# so initials like "Emmett J. Scott" never trigger it.
+_CAP_MARKER = re.compile(r"(?<=[.?])[ \t]+(?=([A-H])\.\s+[A-Z])")
+
+
+def _repair_cap_subparts(text: str) -> str:
+    letters = {m.group(1) for m in _CAP_MARKER.finditer(text)}
+    if not {"A", "B"} <= letters:
+        return text
+    return _CAP_MARKER.sub("\n", text)
+
+
+
+def _repair_enum_breaks(blk: dict) -> list[dict]:
+    """Put mid-prose enumerated sub-parts ('(a) …', '(2) …') on their own lines."""
+    if blk.get("type") == "group":
+        return [dict(blk, blocks=[rb for b in blk.get("blocks", [])
+                                  for rb in _repair_enum_breaks(b)])]
+    if blk.get("type") == "columns":
+        return [dict(blk,
+                     left=[rb for b in blk.get("left", []) for rb in _repair_enum_breaks(b)],
+                     right=[rb for b in blk.get("right", []) for rb in _repair_enum_breaks(b)])]
+    if blk.get("type") in ("paragraph", "labeled", "callout") and isinstance(blk.get("text"), str):
+        fixed = _repair_cap_subparts(_ENUM_MIDPROSE.sub("\n", blk["text"]))
+        if fixed != blk["text"]:
+            return [dict(blk, text=fixed)]
+    return [blk]
+
+
+def _repair_inline_bullets(blk: dict) -> list[dict]:
+    """Split prose containing bullet-marked lines ('• item') into prose + bullets blocks.
+    A paragraph renders newlines as spaces, so bullets written inside a text string run
+    together into one unreadable line."""
+    if blk.get("type") == "group":
+        return [dict(blk, blocks=[rb for b in blk.get("blocks", [])
+                                  for rb in _repair_inline_bullets(b)])]
+    if blk.get("type") == "columns":
+        return [dict(blk,
+                     left=[rb for b in blk.get("left", []) for rb in _repair_inline_bullets(b)],
+                     right=[rb for b in blk.get("right", []) for rb in _repair_inline_bullets(b)])]
+    if blk.get("type") not in ("paragraph", "labeled") or not isinstance(blk.get("text"), str) \
+            or "\n" not in blk["text"]:
+        return [blk]
+    lines = blk["text"].split("\n")
+    if not any(_BULLET_LINE.match(ln) for ln in lines):
+        return [blk]
+    out: list[dict] = []
+    buf: list[str] = []
+    items: list[str] = []
+    first = True
+
+    def flush_text():
+        nonlocal first
+        t = "\n".join(buf).strip()
+        if t:
+            out.append(dict(blk, text=t) if first else {"type": "paragraph", "text": t})
+            first = False
+        buf.clear()
+
+    def flush_items():
+        nonlocal first
+        if items:
+            if first and blk.get("type") == "labeled" and blk.get("label"):
+                # The block opens with bullets — keep its label as a lead-in line
+                # instead of silently dropping it.
+                out.append({"type": "labeled", "label": blk["label"], "text": ""})
+            out.append({"type": "list", "items": list(items)})
+            first = False
+            items.clear()
+
+    for ln in lines:
+        if _BULLET_LINE.match(ln):
+            flush_text()
+            items.append(_BULLET_LINE.sub("", ln, count=1).strip())
+        elif ln.strip():
+            flush_items()
+            buf.append(ln)
+        else:
+            buf.append(ln)  # blank line — stays in whichever prose run is open
+    flush_items()
+    flush_text()
+    return out or [blk]
+
+
+def _repair_pipe_tables(blk: dict) -> list[dict]:
+    """Split a prose block containing a markdown pipe-table run into prose + table blocks."""
+    if blk.get("type") == "group":
+        return [dict(blk, blocks=[rb for b in blk.get("blocks", [])
+                                  for rb in _repair_pipe_tables(b)])]
+    if blk.get("type") == "columns":
+        return [dict(blk,
+                     left=[rb for b in blk.get("left", []) for rb in _repair_pipe_tables(b)],
+                     right=[rb for b in blk.get("right", []) for rb in _repair_pipe_tables(b)])]
+    if btype(blk) in ("list", "checklist"):
+        # A pipe table inside a bullet item: split the list around it and lift the table out.
+        out: list[dict] = []
+        cur: list = []
+        for item in blk.get("items", []):
+            if isinstance(item, str) and _INLINE_SEP.search(item):
+                pieces = _repair_pipe_tables({"type": "paragraph", "text": item})
+                if any(p.get("type") == "table" for p in pieces):
+                    if cur:
+                        out.append(dict(blk, items=cur))
+                        cur = []
+                    out.extend(pieces)
+                    continue
+            cur.append(item)
+        if cur:
+            out.append(dict(blk, items=cur))
+        return out or [blk]
+    if blk.get("type") not in ("paragraph", "labeled", "callout") \
+            or not isinstance(blk.get("text"), str):
+        return [blk]
+    text = blk["text"]
+    if "\n" not in text and _INLINE_SEP.search(text):
+        # Table collapsed onto one line — restore row boundaries ("| |" marks a row break).
+        text = re.sub(r"\|\s+\|", "|\n|", text)
+        blk = dict(blk, text=text)
+    lines = blk["text"].split("\n")
+    if any(_INLINE_SEP.search(ln) for ln in lines):
+        # Prose sharing a line with a table row would be swallowed into the table —
+        # split "intro text: | a | b |" and "| x | y | trailing text" onto separate lines.
+        norm: list[str] = []
+        for ln in lines:
+            m = re.match(r"^([^|]*[^|\s])\s*(\|.+\|)\s*$", ln)
+            if m and not _SEP_LINE.match(ln):
+                norm += [m.group(1), m.group(2)]
+                continue
+            m = re.match(r"^\s*(\|.+\|)\s*([^|]+)$", ln)
+            if m and not _SEP_LINE.match(ln):
+                norm += [m.group(1), m.group(2)]
+                continue
+            norm.append(ln)
+        lines = norm
+    out: list[dict] = []
+    buf: list[str] = []
+    i, first = 0, True
+
+    def flush():
+        nonlocal first
+        t = "\n".join(buf).strip()
+        if t:
+            out.append(dict(blk, text=t) if first else {"type": "paragraph", "text": t})
+            first = False
+        buf.clear()
+
+    while i < len(lines):
+        if _PIPE_LINE.search(lines[i]):
+            j = i
+            while j < len(lines) and (_PIPE_LINE.search(lines[j]) or _SEP_LINE.match(lines[j])):
+                j += 1
+            if sum(1 for k in range(i, j) if not _SEP_LINE.match(lines[k])) >= 2:
+                flush()
+                rows = _parse_pipe_rows(lines[i:j])
+                out.append({"type": "table", "headers": rows[0],
+                            "rows": rows[1:] or [[""] * len(rows[0])]})
+                first = False
+                i = j
+                continue
+        buf.append(lines[i])
+        i += 1
+    flush()
+    return out or [blk]
+
+
+def _doc_text(sections: list[dict]) -> str:
+    parts: list[str] = []
+
+    def walk(v):
+        if isinstance(v, str):
+            parts.append(v)
+        elif isinstance(v, list):
+            for x in v:
+                walk(x)
+        elif isinstance(v, dict):
+            for x in v.values():
+                walk(x)
+
+    walk(sections)
+    return "\n".join(parts)
+
+
+
+# Keys in `shared` that are document/identity metadata, never expanded as content blocks.
+_IDENTITY_KEYS = {"grade", "subject", "duration", "curriculum", "standard_code",
+                  "standard_text", "prerequisite_standard", "smps"}
+
+
+def _is_block(v) -> bool:
+    return isinstance(v, dict) and ("type" in v or "blocks" in v)
+
+
+def _as_blocks(v) -> list[dict]:
+    """Coerce a shared-registry value into renderer blocks. Accepts a block dict, a list of
+    block dicts, a typeless dict carrying the text/label/items field shapes (the schema's
+    stable contract — a `{label, text}` value renders as a labeled block, never as its
+    Python repr), or anything else (-> a single paragraph)."""
+    if v is None or v == "":
+        return []
+    if _is_block(v):
+        return [v]
+    if isinstance(v, dict) and v.get("items"):
+        return [{"type": "list", **{k: v[k] for k in ("label", "items") if k in v}}]
+    if isinstance(v, dict) and v.get("text"):
+        btype = "labeled" if v.get("label") else "paragraph"
+        return [{"type": btype, **{k: v[k] for k in ("label", "text") if k in v}}]
+    if isinstance(v, list) and v and all(_is_block(x) for x in v):
+        return list(v)
+    if isinstance(v, list):
+        return [{"type": "list", "items": [str(x) for x in v]}]
+    return [{"type": "paragraph", "text": str(v)}]
+
+
+def _facet_text(v) -> str:
+    """Flatten a plain facet (string / paragraph / list blocks) to text, or '' if it
+    contains richer blocks that should render as-is."""
+    blocks = _as_blocks(v)
+    if not blocks or not all(b.get("type") in ("paragraph", "list") for b in blocks):
+        return ""
+    return "\n".join(b.get("text", "") if b.get("type") == "paragraph"
+                     else "\n".join(f"- {it}" for it in b.get("items", []))
+                     for b in blocks)
+
+
+def _faceted(val: dict, audience: str) -> list[dict]:
+    """Expand a {teacher?, student?, stimulus?} value.
+
+    Student pages: student facet, then stimulus — the worksheet reads task-then-surface —
+    and nothing else: teacher script never reaches the worksheet, and a null/absent
+    student facet renders nothing (so oral/teacher-led tasks leave no trace).
+
+    Teacher pages: stimulus + teacher facet as plain script, then the
+    student facet as ONE quoted "Students see" line — the teacher reads their own script and
+    the exact prompt students will work from, the way a printed teacher edition shows both.
+    Neither facet is a callout: callouts are reserved for the few moments a teacher must not
+    miss, and a page where every task is boxed highlights nothing."""
+    out: list[dict] = list(_as_blocks(val.get("stimulus")))
+    if audience != "teacher":
+        out[:0] = _as_blocks(val.get("student"))
+        return out
+    t_blocks = _as_blocks(val.get("teacher"))
+    if len(t_blocks) == 1 and t_blocks[0].get("type") == "list":
+        # A list-form script renders as a real list — one glanceable move per line —
+        # not a paragraph with dash-prefixed lines.
+        out.append(t_blocks[0])
+    else:
+        t = _facet_text(val.get("teacher"))
+        if t:
+            out.append({"type": "instructions", "text": t})
+        else:
+            out.extend(t_blocks)
+    s = _facet_text(val.get("student"))
+    if s:
+        out.append({"type": "labeled", "label": "Students see", "text": s})
+    else:
+        out.extend(_as_blocks(val.get("student")))
+    return out
+
+
+def expand_from_shared(key: str, shared: dict, audience: str = "teacher",
+                       blk: dict | None = None) -> list[dict]:
+    """Expand a `{"type": "from_shared", "key": ...}` block into plain renderer blocks.
+
+    The registry is freeform: any key the model registered in `shared` resolves the same way.
+    The only special case is `standard`, which is stored under `standard_code`/`standard_text`
+    rather than a single key.
+
+    audience: "teacher" (lesson plan / observation) or "student" (worksheet).
+    blk: the originating from_shared block — carries an optional `label` for numbered tasks.
+    """
+    shared = dict(shared or {})
+    if key == "standard":
+        if not (shared.get("standard_text") or shared.get("standard_code")):
+            return []
+        return [{"type": "callout", "kind": "special",
+                 "label": f"{shared.get('standard_code', '')} — Target standard".strip(" —"),
+                 "text": shared.get("standard_text", "")}]
+
+    val = shared.get(key)
+    if val is None or val == "" or val == []:
+        return []
+    if key in _IDENTITY_KEYS:
+        return [{"type": "paragraph", "text": str(val)}]
+
+    if isinstance(val, dict) and not _is_block(val) and (
+            "teacher" in val or "student" in val or "stimulus" in val):
+        out = _faceted(val, audience)
+    else:
+        out = _as_blocks(val)
+
+    # `{type: from_shared, key: p1, label: "1"}` — fold the label into the first text-bearing
+    # block (scanning past leading diagram blocks, which have nothing to fold into) so a
+    # numbered prompt renders on one line, not an orphan number above a paragraph.
+    # A label must never render alone. Dispatch on that block's FIELDS, not its
+    # type name — type names change (callout -> instructions broke the old version of
+    # this); the text/label/items field shapes are the schema's stable contract.
+    label = (blk or {}).get("label")
+    if label and out:
+        i = next((j for j, b in enumerate(out)
+                  if b.get("label") or b.get("text") or b.get("items")), 0)
+        first = out[i]
+        if first.get("label"):
+            out[i] = {**first, "label": f"{label}. {first['label']}"}
+        elif first.get("text"):
+            out[i] = {"type": "labeled", "label": str(label), "text": first["text"]}
+        elif first.get("items"):
+            items = list(first["items"])
+            out[i] = {"type": "labeled", "label": str(label), "text": str(items[0])}
+            if items[1:]:
+                out.insert(i + 1, {**first, "items": items[1:]})
+        else:
+            out.insert(i, {"type": "labeled", "label": str(label), "text": ""})
+    return out
+
+
+def expand_blocks(blocks: list, shared: dict, audience: str = "teacher") -> list[dict]:
+    """Replace any from_shared blocks in a block list (recursing into columns and groups)."""
+    out: list[dict] = []
+    for blk in blocks or []:
+        btype = blk.get("type")
+        if btype == "from_shared":
+            out.extend(expand_from_shared(blk.get("key", ""), shared, audience, blk))
+        elif btype == "columns":
+            out.append({"type": "columns",
+                        "left": expand_blocks(blk.get("left", []), shared, audience),
+                        "right": expand_blocks(blk.get("right", []), shared, audience)})
+        elif btype == "group":
+            out.append({**blk, "blocks": expand_blocks(blk.get("blocks", []), shared, audience)})
+        else:
+            out.append(blk)
+    return out
+
+
+_PROMPT_TYPES = ("paragraph", "labeled", "callout", "list", "h3")
+
+
+def _pair_writing_space(blocks: list[dict]) -> list[dict]:
+    """Glue a prompt block to the workspace/answer_box that follows it so a page break can
+    never separate a question from its writing space (renderers keep groups together).
+    Types are compared post-alias (btype) so canonical and legacy names both pair."""
+    out: list[dict] = []
+    i = 0
+    while i < len(blocks):
+        b = blocks[i]
+        if (btype(b) in _PROMPT_TYPES and i + 1 < len(blocks)
+                and btype(blocks[i + 1]) == "workspace"):
+            out.append({"type": "group", "blocks": [b, blocks[i + 1]]})
+            i += 2
+            continue
+        out.append(b)
+        i += 1
+    return out
+
+
+def _strip_heading_echo(section: dict) -> dict:
+    """Drop a leading repeat of the section heading from the first text block —
+    'If you finish early' + text starting 'If you finish early: …' prints twice."""
+    heading = str(section.get("heading", "")).strip().rstrip(":").strip()
+    blocks = section.get("blocks") or []
+    if not heading or len(heading) < 4 or not blocks:
+        return section
+    first = blocks[0]
+    btype = first.get("type")
+    target = first if btype in ("paragraph", "labeled", "callout") else None
+    if btype == "group" and first.get("blocks"):
+        inner = first["blocks"][0]
+        target = inner if inner.get("type") in ("paragraph", "labeled", "callout") else None
+    if not target or not isinstance(target.get("text"), str):
+        return section
+    m = re.match(r"\s*\**" + re.escape(heading) + r"\**\s*[:!.—–-]\s*", target["text"],
+                 re.IGNORECASE)
+    if not m or not target["text"][m.end():].strip():
+        return section
+    fixed = dict(target, text=target["text"][m.end():])
+    if btype == "group":
+        new_first = dict(first, blocks=[fixed] + first["blocks"][1:])
+    else:
+        new_first = fixed
+    return {**section, "blocks": [new_first] + blocks[1:]}
+
+
+def expand_document(data: dict, audience: str = "teacher") -> dict:
+    """Return a copy of a document dict with all from_shared blocks expanded."""
+    shared = data.get("shared", {})
+    doc = dict(data)
+    doc["sections"] = [
+        {**s, "blocks": expand_blocks(s.get("blocks", []), shared, audience)}
+        for s in data.get("sections", [])
+    ]
+    # Print-safety repair pass — post-expansion so it covers model prose AND shared content,
+    # in every artifact and both output formats (HTML and docx render through here).
+    doc["sections"] = [
+        {**s, "blocks": _pair_writing_space(
+            [rb for b in s.get("blocks", [])
+             for eb in _repair_enum_breaks(b)
+             for tb in _repair_pipe_tables(eb)
+             for rb in _repair_inline_bullets(tb)])}
+        for s in doc["sections"]
+    ]
+    doc["sections"] = [_strip_heading_echo(s) for s in doc["sections"]]
+    text = _doc_text(doc["sections"])
+    if UNKNOWN_SYMBOL in text and not _UNKNOWN_DEFINED.search(text):
+        for s in doc["sections"]:
+            if UNKNOWN_SYMBOL in _doc_text([s]):
+                s.setdefault("blocks", []).append(
+                    {"type": "paragraph",
+                     "text": "*The symbol ■ stands for the unknown number.*"})
+                break
+    return doc
+
+
+# ============================================================================
+# Shared rendering primitives — format-agnostic helpers used by every renderer.
+# Moved from render_lesson_html.py so render_lesson_docx.py can import the same
+# theme, alias, callout, and grade-band logic without duplication.
+# ============================================================================
+
+DEFAULT_THEME = {
+    "primary": "#17A267", "title_color": "#14613F",
+    "text": "#222222", "muted": "#666666", "rule": "#D0D4D8", "border": "#CBD2D8",
+    "title_size": 22, "body_size": 10.5,
+}
+HEX = re.compile(r"^#[0-9A-Fa-f]{3,8}$")
+
+# Legacy block-type names -> canonical names. Keeps existing lesson JSONs rendering.
+ALIASES = {"subheading": "h3", "bullets": "list", "answer_box": "workspace",
+           "data_table": "table",
+           # frame_bank retired as a component: legacy JSON renders as a plain
+           # labeled list — sentence supports are ordinary text the model
+           # composes, not a boxed special.
+           "frame_bank": "list"}
+
+
+def btype(blk: dict) -> str:
+    t = blk.get("type") or "paragraph"
+    return ALIASES.get(t, t)
+
+
+# Callout kinds: semantic name -> (icon, css class). Legacy `style`/`role` values map in.
+CALLOUT_KINDS = {
+    "special":      ("⭐", "special"),
+    "student-task": ("📌", "task"),
+    "teacher-note": ("✋", "tnote"),
+    "student-note": ("✋", "snote"),
+}
+CALLOUT_ALIASES = {
+    "accent": "special", "standard": "special",
+    "info": "student-task", "activity": "student-task",
+    "note": "teacher-note", "tip": "teacher-note",
+    "warning": "teacher-note", "caution": "teacher-note", "important": "special",
+}
+
+
+def resolve_callout_kind(blk: dict) -> str:
+    raw = str(blk.get("kind") or blk.get("role") or blk.get("style") or "student-task").lower()
+    return raw if raw in CALLOUT_KINDS else CALLOUT_ALIASES.get(raw, "student-task")
+
+
+class Theme:
+    def __init__(self, overrides: dict | None):
+        t = dict(DEFAULT_THEME)
+        t.update(overrides or {})
+        self.raw = t
+        self.answer_height, self.answer_gap, self.answer_row = 120.0, 22.0, 96.0
+        self.ruled_default = False
+        self.student_doc = False
+
+    def safe(self, key: str) -> str:
+        val = str(self.raw.get(key, DEFAULT_THEME.get(key, "")))
+        return val if HEX.match(val) else str(DEFAULT_THEME.get(key, "#222222"))
+
+
+def meta_text(meta) -> str:
+    """Normalize `meta` to a display string. The schema says it's a string, but models
+    sometimes emit a list of {label, value} dicts — join those as 'Label: value · …'."""
+    if isinstance(meta, dict):
+        meta = [meta]
+    if isinstance(meta, (list, tuple)):
+        parts = []
+        for item in meta:
+            if isinstance(item, dict):
+                label = str(item.get("label") or "").rstrip(":").strip()
+                value = str(item.get("value") or item.get("text") or "").strip()
+                parts.append(f"{label}: {value}" if label and value else (value or label))
+            elif item:
+                parts.append(str(item))
+        return " · ".join(p for p in parts if p)
+    return str(meta) if meta else ""
+
+
+def grade_number(data: dict):
+    """Best-effort grade parse: 0 for K, 1-12, or None."""
+    shared = data.get("shared") or {}
+    for src in (data.get("grade"), shared.get("grade") if isinstance(shared, dict) else None):
+        s = str(src or "").strip().lower()
+        if not s:
+            continue
+        if s.startswith("k") or "kind" in s:
+            return 0
+        m = re.search(r"\d{1,2}", s)
+        if m:
+            return int(m.group(0))
+    for which, src in (("eyebrow", data.get("eyebrow")), ("meta", meta_text(data.get("meta")))):
+        s = str(src or "").lower()
+        if "kindergarten" in s:
+            return 0
+        m = (re.search(r"\bgrade[:\s]*(k|\d{1,2})\b", s)
+             or re.search(r"\b(\d{1,2})(?:st|nd|rd|th)[\s-]*grade\b", s))
+        if not m and which == "eyebrow":
+            m = re.search(r"^\s*(k|1[0-2]|[1-9])(?:st|nd|rd|th)?\b"
+                          r"(?!\s*(?:min|minute|hour|problem|tier|page|point|task|question))", s)
+        if m:
+            g = m.group(1)
+            return 0 if g == "k" else int(g)
+    return None
+
+
+def answer_profile(data: dict) -> tuple:
+    """Grade-banded writing-space defaults:
+    (height pt, ruled line gap pt, table-row pt, ruled by default).
+
+    Math work space is open by default; a block's explicit `ruled: true`
+    still gets the band's gap, so a grade-1 sentence answer gets K-2 pitch."""
+    n = grade_number(data)
+    if n is None:
+        return 120.0, 22.0, 96.0, False
+    shared = data.get("shared")
+    shared = shared if isinstance(shared, dict) else {}
+    # smps (Standards for Mathematical Practice) is the most reliable math signal — it is
+    # math-only and the math reference mandates it, whereas shared.subject is often omitted.
+    is_math = bool(shared.get("smps")) or "math" in " ".join(str(x or "") for x in (
+        shared.get("subject"), data.get("eyebrow"), data.get("title"))).lower()
+    if n <= 2:
+        return 200.0, 40.0, 160.0, not is_math
+    if n <= 5:
+        return 150.0, 28.0, 126.0, not is_math
+    if n <= 8:
+        return 130.0, 24.0, 108.0, False
+    return 116.0, 22.0, 96.0, False
+
+
+def coerce_marks(raw):
+    """Number-line marks: bare numbers or {position/value, label} dicts -> [(value, label)].
+    Models write both forms; a mark the renderer can't read must never vanish silently —
+    a task that says "the point for 1/6 is shown" depends on it being drawn."""
+    out = []
+    for m in raw or []:
+        if isinstance(m, (int, float)) and not isinstance(m, bool):
+            out.append((float(m), None))
+        elif isinstance(m, dict):
+            v = m.get("position", m.get("value", m.get("x")))
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                lab = m.get("label")
+                out.append((float(v), str(lab) if lab not in (None, "") else None))
+    return out
+
+
+WORKSPACE_SIZES = {"small": 70.0, "med": 130.0, "large": 220.0}
+FILL_IN_CHARS = {"short": 12, "med": 28, "long": 60}  # underscore counts for non-CSS formats
+
+
+def workspace_height(blk: dict, theme: Theme) -> float:
+    """Resolve a workspace block's height in points (format-agnostic)."""
+    h = blk.get("height_pt")
+    if h is None:
+        h = WORKSPACE_SIZES.get(str(blk.get("size", "")).lower())
+    if h is None:
+        h = theme.answer_height
+    try:
+        return float(h)
+    except (TypeError, ValueError):
+        return float(theme.answer_height)
+
+
+def label_text(blk: dict) -> str:
+    """Normalized label string — strips a trailing colon so renderers can add their own
+    consistently without doubling it."""
+    return str(blk.get("label", "")).rstrip(":")
+
+
+def label_sep(label: str) -> str:
+    """Separator after a label: numeric labels (task numbers like "1", "2a") get a period;
+    word labels ("Anchor task", "Exit ticket") get a colon. A label that already ends in a
+    period gets no extra separator."""
+    s = label.strip()
+    if s.endswith("."):
+        return ""
+    return "." if re.fullmatch(r"\d+[a-z]?", s, re.IGNORECASE) else ":"
+
+
+def normalize_text(text) -> str:
+    """Format-agnostic text fixups applied before any inline-markdown parse."""
+    t = str(text)
+    t = re.sub(r"(?<!_)_{3,9}(?!_)", "______", t)
+    t = re.sub(r"\s+\|\s+", " · ", t)
+    return t
+
+
+_MD_TOKEN = re.compile(r"(\*\*.+?\*\*|(?<!\*)\*(?!\s).+?(?<!\s)\*(?!\*)|\n)")
+
+
+def md_tokens(text) -> list:
+    """Parse mini-markdown into format-neutral tokens.
+
+    Returns a list of (text, attrs) where attrs is a dict with optional 'bold',
+    'italic', 'break' keys. normalize_text() is applied first."""
+    t = normalize_text(text)
+    out = []
+    for part in _MD_TOKEN.split(t):
+        if not part:
+            continue
+        if part == "\n":
+            out.append(("", {"break": True}))
+        elif part.startswith("**") and part.endswith("**"):
+            out.append((part[2:-2], {"bold": True}))
+        elif part.startswith("*") and part.endswith("*"):
+            out.append((part[1:-1], {"italic": True}))
+        else:
+            out.append((part, {}))
+    return out
+
+
+def coerce_rows(rows) -> list[list]:
+    """Normalize model-emitted table rows. Each row must be a list of cells, but models
+    sometimes emit a bare string ("Total: $5.99"), a dict ({"label": ..., "value": ...}),
+    or null — coerce instead of crashing (docx KeyError) or garbling (one cell per
+    character); null becomes a blank write-in row."""
+    if isinstance(rows, str):
+        # The whole rows value drawn as one pipe string — restore rows and cells.
+        rows = _parse_pipe_rows(rows.splitlines()) if "|" in rows else [[rows]]
+    out: list[list] = []
+    for r in rows or []:
+        if isinstance(r, list):
+            out.append(r)
+        elif isinstance(r, dict):
+            out.append(list(r.values()))
+        elif r is None:
+            out.append([])
+        else:
+            out.append([str(r)])
+    return out
+
+
+def coerce_headers(headers) -> list:
+    """Normalize table headers. A bare string ("Item | Cost") is the pipe-joined header
+    row a model meant — split it; a dict's values are its labels; any other non-list
+    becomes a single header."""
+    if isinstance(headers, list):
+        return headers
+    if not headers:
+        return []
+    if isinstance(headers, dict):
+        return list(headers.values())
+    s = str(headers)
+    if "|" in s:
+        parsed = _parse_pipe_rows([s])
+        return parsed[0] if parsed else []
+    return [s]
+
+
+def table_row_height(blk: dict, theme: Theme, *, full_blank: bool) -> float:
+    """Minimum height (pt) for a table row containing empty writing-space cells.
+    An explicit empty_row_height_pt / row_height_pt wins (floored at the 40pt
+    writable minimum the deterministic checks enforce) — a sort grid whose cells
+    take an X is deliberately shorter than a sentence row, and flooring it to
+    the grade band printed near-blank pages of grid. The band sizes rows only
+    when the model didn't say."""
+    try:
+        explicit = float(blk.get("empty_row_height_pt")
+                         or blk.get("row_height_pt") or 0)
+    except (TypeError, ValueError):
+        explicit = 0.0
+    band = theme.answer_row
+    if theme.student_doc:
+        if explicit:
+            return max(explicit, 40.0)
+        return band if full_blank else 0.45 * band
+    return explicit or 36.0
+
+
+def preamble_blocks(data: dict) -> list[dict]:
+    """Top-level standard / prerequisite / practices blocks rendered between the header
+    and the first section. Shared by both formats so the preamble can never drift."""
+    blocks: list[dict] = []
+    if data.get("standard_text"):
+        label = f"{data.get('standard_code', '')} — Target standard".strip(" —")
+        blocks.append({"type": "callout", "kind": "special", "label": label,
+                       "text": data["standard_text"]})
+    if data.get("prerequisite_standard"):
+        blocks.append({"type": "labeled", "label": "Builds on",
+                       "text": data["prerequisite_standard"]})
+    if data.get("smps"):
+        blocks.append({"type": "labeled", "label": "Mathematical practices",
+                       "text": "; ".join(data["smps"])})
+    return blocks
+
+
+def build_header(data: dict) -> dict:
+    """Format-agnostic header fields: eyebrow, title, meta string, optional name_line."""
+    meta = meta_text(data.get("meta"))
+    if not meta:
+        bits = [data.get("standard_code"), data.get("grade"), data.get("duration"),
+                data.get("curriculum")]
+        if data.get("materials"):
+            bits.append("Materials: " + ", ".join(data["materials"]))
+        meta = " · ".join(str(b) for b in bits if b)
+    name_line = ""
+    if meta and data.get("audience") == "student" and re.search(r"name\s*:", meta, re.I):
+        name_line, meta = meta, ""
+    return {"eyebrow": data.get("eyebrow", ""), "title": data.get("title", "Lesson Plan"),
+            "meta": meta, "name_line": name_line}

--- a/skill-library/k12-lesson-differentiation/scripts/render_all.sh
+++ b/skill-library/k12-lesson-differentiation/scripts/render_all.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+# Render all four artifacts (teacher plan + three tier worksheets) from one
+# differentiation.json in a single invocation. Writes editable .docx (the teacher
+# deliverable) and an .html twin of each (a preview that renders even without python-docx).
+# Fail-fast: any renderer error stops the run.
+#
+# Usage: bash scripts/render_all.sh differentiation.json "$OUTPUT_DIR"
+set -euo pipefail
+
+json="${1:?usage: render_all.sh DIFFERENTIATION_JSON OUTPUT_DIR}"
+outdir="${2:?usage: render_all.sh DIFFERENTIATION_JSON OUTPUT_DIR}"
+here="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p "$outdir"
+# python-docx powers the .docx output; the .html twins render without it. If the install
+# can't complete (offline container), render html now so the twins always exist.
+if ! python3 -c "import docx" 2>/dev/null; then
+  python3 -m pip install -q "python-docx==1.1.2" || true
+fi
+if python3 -c "import docx" 2>/dev/null; then
+  python3 "$here/render_documents.py" "$json" --format both --outdir "$outdir"
+else
+  # Render the html twins so a readable preview still exists, then fail loudly: the
+  # teacher's .docx deliverables could not be produced.
+  python3 "$here/render_documents.py" "$json" --format html --outdir "$outdir"
+  echo "error: python-docx could not be installed — no .docx deliverables were produced" >&2
+  exit 1
+fi
+# Persist the source JSON alongside the rendered artifacts so later revision
+# turns can re-render from it (same guarantee the lesson-planning renderer
+# makes with lesson.json).
+cp "$json" "$outdir/differentiation.json" 2>/dev/null || true
+
+# Delivery guarantee: when $OUTPUT_DIR is set and the render went elsewhere
+# (a staging dir like /tmp/out), mirror EVERYTHING into $OUTPUT_DIR too.
+# Revision turns re-render from the differentiation.json that lands there;
+# hand-copying a subset there is the failure this removes.
+if [ -n "${OUTPUT_DIR:-}" ] && [ "$(cd "$outdir" && pwd)" != "$(mkdir -p "$OUTPUT_DIR" && cd "$OUTPUT_DIR" && pwd)" ]; then
+  cp -R "$outdir"/. "$OUTPUT_DIR"/
+fi

--- a/skill-library/k12-lesson-differentiation/scripts/render_documents.py
+++ b/skill-library/k12-lesson-differentiation/scripts/render_documents.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render every document in a multi-document source JSON (HTML previews and/or editable .docx).
+
+Used by skills whose output is a set of documents that must stay consistent with each other
+(e.g. the differentiation skills: 1 teacher plan + 3 tiered worksheets). The source JSON holds
+ONE `shared` block (content that appears in more than one document) plus a `documents` array.
+Each document is a full block-document — same schema as render_lesson_html.py /
+render_lesson_docx.py (eyebrow / title / meta / sections / theme / audience) — and pulls shared
+content with {"type": "from_shared", "key": ...} blocks, so shared content is written once and
+cannot drift between documents.
+
+Material source shape:
+  {
+    "shared": {"standard_code": ..., "standard_text": ...,
+               <any model-chosen keys: a block, a list of blocks, or a faceted
+                {teacher, student, stimulus} value>, ...},
+    "theme": {...},                              // default theme for every document
+    "documents": [
+      {"id": "teacher_plan",      "audience": "teacher", "title": ..., "sections": [...]},
+      {"id": "worksheet_group_a", "audience": "student", "title": ..., "sections": [...]},
+      {"id": "worksheet_group_b", "audience": "student", "title": ..., "sections": [...]},
+      {"id": "worksheet_group_c", "audience": "student", "title": ..., "sections": [...]}
+    ]
+  }
+
+`id` becomes the output filename; a document's own `theme` overrides the top-level one.
+
+Usage:
+    python render_documents.py differentiation.json --format html             # all docs -> HTML previews
+    python render_documents.py differentiation.json --format docx             # all docs -> editable .docx
+    python render_documents.py differentiation.json --only worksheet_group_a worksheet_group_b --format docx
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def build_doc(source: dict, doc: dict) -> dict:
+    """Merge a document entry with the source's shared block and default theme."""
+    out = dict(doc)
+    out.setdefault("shared", source.get("shared", {}))
+    theme = dict(source.get("theme") or {})
+    theme.update(doc.get("theme") or {})
+    if theme:
+        out["theme"] = theme
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("input", help="source JSON with a `documents` array")
+    ap.add_argument("--format", choices=["html", "docx", "both"], default="html")
+    ap.add_argument("--only", nargs="*", default=None,
+                    help="document ids to render (default: all)")
+    ap.add_argument("--outdir", default=".")
+    args = ap.parse_args()
+
+    source = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    docs = source.get("documents", [])
+    if not docs:
+        print("error: no `documents` array in input", file=sys.stderr)
+        return 1
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    written = []
+    for i, doc in enumerate(docs):
+        # Sanitize the document id before it becomes a filename: the id comes from generated
+        # JSON, so strip path separators and anything outside [A-Za-z0-9_-].
+        doc_id_raw = str(doc.get("id") or f"document_{i + 1}")
+        doc_id = re.sub(r"[^A-Za-z0-9_\-]", "_", Path(doc_id_raw).name) or f"document_{i + 1}"
+        if args.only and doc_id_raw not in args.only and doc_id not in args.only:
+            continue
+        full = build_doc(source, doc)
+        # The HTML twin always ships — docx is the teacher deliverable, html is its
+        # always-available preview. Rendering docx alone leaves the twin missing, so
+        # "docx" implies both.
+        from render_lesson_html import render as render_html
+        path = outdir / f"{doc_id}.html"
+        path.write_text(render_html(full), encoding="utf-8")
+        written.append(str(path))
+        if args.format in ("docx", "both"):
+            from render_lesson_docx import render as render_docx
+            path = outdir / f"{doc_id}.docx"
+            render_docx(full, str(path))
+            written.append(str(path))
+
+    if not written:
+        print("nothing rendered — check --only ids against the documents' `id` fields",
+              file=sys.stderr)
+        return 1
+    print("wrote " + ", ".join(written))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skill-library/k12-lesson-differentiation/scripts/render_lesson_docx.py
+++ b/skill-library/k12-lesson-differentiation/scripts/render_lesson_docx.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render lesson JSON -> an editable .docx (the teacher-editable deliverable).
+
+Same input schema and block vocabulary as render_lesson_html.py; consumes the same
+expand_document() / theme / alias / callout-kind helpers from lesson_common, so the two
+formats stay in sync by construction. Styling follows the same visual design principles:
+minimal color, icon-prefixed callouts (no fill), B+W-safe.
+
+Usage:
+    python render_lesson_docx.py lesson.json -o lesson_plan.docx
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lesson_common import (  # noqa: E402
+    Theme, CALLOUT_KINDS, FILL_IN_CHARS, btype as _btype,
+    resolve_callout_kind, answer_profile, build_header, expand_document, coerce_marks,
+    md_tokens, workspace_height, label_text, label_sep, table_row_height, preamble_blocks,
+    coerce_headers, coerce_rows,
+)
+
+try:
+    from docx import Document
+    from docx.shared import Pt, RGBColor, Inches
+    from docx.enum.text import WD_TAB_ALIGNMENT, WD_BREAK, WD_ALIGN_PARAGRAPH
+    from docx.enum.table import WD_ROW_HEIGHT_RULE
+    from docx.oxml.ns import qn
+    from docx.oxml import OxmlElement
+except ImportError:  # pragma: no cover
+    print("error: python-docx is required — pip install \"python-docx==1.1.2\"",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+# ---- styles ------------------------------------------------------------------
+
+def _hex_rgb(hex_str: str) -> RGBColor:
+    h = hex_str.lstrip("#")
+    if len(h) in (3, 4):  # expand short hex (#1a7 -> #11aa77); HEX in lesson_common accepts 3-8 chars
+        h = "".join(c * 2 for c in h[:3])
+    h = (h + "000000")[:6]
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def setup_styles(doc, theme: Theme):
+    body = float(theme.raw.get("body_size", 10.5))
+    s = doc.styles
+    s["Normal"].font.name = "Helvetica"
+    s["Normal"].font.size = Pt(body)
+    # Pin Normal to the html stylesheet's 8pt-after; otherwise Word's template
+    # default of 10pt-after leaks into every plain paragraph.
+    s["Normal"].paragraph_format.space_before = Pt(0)
+    s["Normal"].paragraph_format.space_after = Pt(8)
+    for name, size, bold, color, before, after in [
+        ("LC Eyebrow", 9, True, theme.safe("primary"), 0, 2),
+        ("LC Title", float(theme.raw.get("title_size", 22)), True, theme.safe("text"), 2, 2),
+        ("LC Meta", 9, False, theme.safe("muted"), 0, 12),
+        ("LC H1", 14, True, theme.safe("text"), 18, 8),
+        ("LC H2", 12, True, theme.safe("primary"), 12, 4),
+        ("LC H3", body, True, theme.safe("text"), 8, 4),
+        ("LC Instr", body, False, theme.safe("text"), 4, 6),
+        ("LC Muted", 8.5, False, theme.safe("muted"), 4, 0),
+        ("LC Spacer", 2, False, theme.safe("muted"), 4, 0),
+    ]:
+        st = s.add_style(name, 1)  # 1 = WD_STYLE_TYPE.PARAGRAPH
+        st.base_style = s["Normal"]
+        st.font.size = Pt(size)
+        st.font.bold = bold
+        st.font.color.rgb = _hex_rgb(color)
+        st.paragraph_format.space_before = Pt(before)
+        st.paragraph_format.space_after = Pt(after)
+    s["LC Eyebrow"].font.all_caps = True
+    # The structural paragraph dropped after every table-rendered block (callout,
+    # cards, workspace, table) — OOXML wants a paragraph between consecutive
+    # tables. Exact 2pt line height keeps it from reading as a blank line.
+    s["LC Spacer"].paragraph_format.line_spacing = Pt(2)
+
+
+# ---- inline runs -------------------------------------------------------------
+
+def add_md(para, text, bold=False, italic=False):
+    """Add mini-markdown text to a paragraph as runs."""
+    for t, attrs in md_tokens(text):
+        if attrs.get("break"):
+            para.add_run().add_break()
+            continue
+        r = para.add_run(t)
+        r.bold = bold or attrs.get("bold", False)
+        r.italic = italic or attrs.get("italic", False)
+
+
+# ---- table primitives --------------------------------------------------------
+
+def _set_borders(tbl, color="CBD2D8", sides=("top", "bottom", "left", "right",
+                                             "insideH", "insideV")):
+    pr = tbl._tbl.tblPr
+    borders = pr.find(qn("w:tblBorders"))
+    if borders is None:
+        borders = OxmlElement("w:tblBorders")
+        pr.append(borders)
+    for side in sides:
+        el = OxmlElement(f"w:{side}")
+        el.set(qn("w:val"), "single")
+        el.set(qn("w:sz"), "6")
+        el.set(qn("w:color"), color)
+        borders.append(el)
+
+
+def _set_cell_margins(tbl):
+    """Internal cell padding (twips; 100 twips = 5pt). Word's default top/bottom is 0,
+    which makes cell text sit flush against the top border in most viewers."""
+    pr = tbl._tbl.tblPr
+    mar = OxmlElement("w:tblCellMar")
+    for side, val in (("top", 100), ("bottom", 100), ("left", 120), ("right", 120)):
+        el = OxmlElement(f"w:{side}")
+        el.set(qn("w:w"), str(val))
+        el.set(qn("w:type"), "dxa")
+        mar.append(el)
+    pr.append(mar)
+
+
+def _cant_split(tbl):
+    """Mark every row as non-splitting so a table (callout, card row, data row) never
+    breaks across a page boundary mid-row."""
+    for row in tbl.rows:
+        trpr = row._tr.get_or_add_trPr()
+        trpr.append(OxmlElement("w:cantSplit"))
+
+
+def _shade_cell(cell, fill="F6F8F9"):
+    pr = cell._tc.get_or_add_tcPr()
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:fill"), fill)
+    pr.append(shd)
+
+
+def _list_number_abstract_id(doc) -> str | None:
+    """Return the abstractNumId that the built-in 'List Number' style binds to."""
+    try:
+        # _Cell has no .styles; resolve via the part (cell.part is the DocumentPart).
+        styles = doc.styles if hasattr(doc, "styles") else doc.part.document.styles
+        st = styles["List Number"].element
+        nid = st.find(qn("w:pPr")).find(qn("w:numPr")).find(qn("w:numId")).get(qn("w:val"))
+        for n in doc.part.numbering_part.element.findall(qn("w:num")):
+            if n.get(qn("w:numId")) == nid:
+                return n.find(qn("w:abstractNumId")).get(qn("w:val"))
+    except (AttributeError, KeyError):
+        pass
+    return None
+
+
+def _restart_numbering(doc, paras: list):
+    """Give an ordered list its own numId so it restarts at 1 instead of continuing
+    the previous one (python-docx's built-in 'List Number' style shares one numId
+    document-wide). Stamps EVERY paragraph in the list."""
+    abstract_id = _list_number_abstract_id(doc)
+    if abstract_id is None:
+        return
+    numbering = doc.part.numbering_part.element
+    nums = numbering.findall(qn("w:num"))
+    new_id = max(int(n.get(qn("w:numId"))) for n in nums) + 1
+    new = OxmlElement("w:num")
+    new.set(qn("w:numId"), str(new_id))
+    abst = OxmlElement("w:abstractNumId")
+    abst.set(qn("w:val"), abstract_id)
+    new.append(abst)
+    ovr = OxmlElement("w:lvlOverride")
+    ovr.set(qn("w:ilvl"), "0")
+    start = OxmlElement("w:startOverride")
+    start.set(qn("w:val"), "1")
+    ovr.append(start)
+    new.append(ovr)
+    numbering.append(new)
+    for p in paras:
+        npr = p._p.get_or_add_pPr().get_or_add_numPr()
+        npr.get_or_add_ilvl().val = 0
+        npr.get_or_add_numId().val = new_id
+
+
+def _keep_with_next(para):
+    para.paragraph_format.keep_with_next = True
+    para.paragraph_format.keep_together = True
+
+
+def _box(doc, theme: Theme):
+    """A 1x1 bordered table used for callouts."""
+    t = doc.add_table(rows=1, cols=1)
+    t.autofit = True
+    _set_borders(t, color=theme.safe("border").lstrip("#"),
+                 sides=("top", "bottom", "left", "right"))
+    _set_cell_margins(t)
+    _cant_split(t)
+    cell = t.rows[0].cells[0]
+    cell.paragraphs[0].text = ""
+    return cell
+
+
+def _content_width(doc) -> float:
+    """Usable text width in inches (page width minus margins)."""
+    s = doc.sections[0]
+    return (s.page_width - s.left_margin - s.right_margin) / 914400  # EMU per inch
+
+
+# ---- per-block emitters ------------------------------------------------------
+
+def _emit_paragraph(doc, blk, theme):
+    add_md(doc.add_paragraph(), blk.get("text", ""))
+
+
+def _emit_labeled(doc, blk, theme):
+    p = doc.add_paragraph()
+    lbl = label_text(blk)
+    add_md(p, f"{lbl}{label_sep(lbl)} ", bold=True)
+    add_md(p, blk.get("text", ""))
+
+
+def _emit_heading(style):
+    def _f(doc, blk, theme):
+        doc.add_paragraph(style=style).add_run(str(blk.get("text", "")))
+    return _f
+
+
+def _emit_instructions(doc, blk, theme):
+    add_md(doc.add_paragraph(style="LC Instr"), blk.get("text", ""))
+
+
+def _label_para(doc, blk):
+    # Hug the block it introduces (html .listlabel: 2pt below).
+    lp = doc.add_paragraph()
+    add_md(lp, label_text(blk), bold=True)
+    lp.paragraph_format.space_before = Pt(2)
+    lp.paragraph_format.space_after = Pt(2)
+
+
+def _emit_list(doc, blk, theme, *, checklist=False):
+    if blk.get("label"):
+        _label_para(doc, blk)
+    ordered = bool(blk.get("ordered"))
+    style = "List Number" if ordered else "List Bullet"
+    paras = []
+    for item in blk.get("items", []):
+        p = doc.add_paragraph(style=style)
+        if checklist:
+            p.add_run("☐  ")
+        add_md(p, item)
+        paras.append(p)
+    if ordered and paras:
+        _restart_numbering(doc, paras)
+
+
+def _emit_callout(doc, blk, theme):
+    kind = resolve_callout_kind(blk)
+    icon, _ = CALLOUT_KINDS[kind]
+    cell = _box(doc, theme)
+    lp = cell.paragraphs[0]
+    lp.add_run(icon + "  ")
+    if blk.get("label"):
+        add_md(lp, label_text(blk), bold=True)
+    text = blk.get("text") or blk.get("body") or blk.get("content") or ""
+    if text:
+        add_md(cell.add_paragraph(), text)
+    doc.add_paragraph(style="LC Spacer")
+
+
+def _emit_cards(doc, blk, theme):
+    items = blk.get("items", [])
+    if not items:
+        return
+    tbl = doc.add_table(rows=1, cols=len(items))
+    _set_borders(tbl, color=theme.safe("border").lstrip("#"))
+    _set_cell_margins(tbl)
+    _cant_split(tbl)
+    for i, c in enumerate(items):
+        c = c if isinstance(c, dict) else {"title": str(c), "text": ""}
+        cell = tbl.rows[0].cells[i]
+        add_md(cell.paragraphs[0], c.get("title", ""), bold=True)
+        add_md(cell.add_paragraph(), c.get("text", ""))
+    doc.add_paragraph(style="LC Spacer")
+
+
+def _emit_fill_in(doc, blk, theme):
+    n = FILL_IN_CHARS.get(str(blk.get("size", "med")).lower(), FILL_IN_CHARS["med"])
+    p = doc.add_paragraph()
+    if blk.get("label"):
+        add_md(p, label_text(blk) + ": ", bold=True)
+    p.add_run("_" * n)
+
+
+def _emit_phase_header(doc, blk, theme):
+    p = doc.add_paragraph(style="LC H2")
+    p.paragraph_format.keep_with_next = True
+    p.paragraph_format.tab_stops.add_tab_stop(Inches(theme.content_width),
+                                              WD_TAB_ALIGNMENT.RIGHT)
+    p.add_run(str(blk.get("name", "")))
+    if blk.get("minutes") is not None:
+        r = p.add_run(f"\t{blk['minutes']} min")
+        r.font.bold = False
+        r.font.color.rgb = _hex_rgb(theme.safe("muted"))
+
+
+def _emit_group(doc, blk, theme):
+    # A prompt or label never strands from the surface below it: text-bearing
+    # paragraphs keep with what follows. Spacers do NOT chain — a multi-surface
+    # question (two number lines + a box, 400pt+) as one atomic unit forces Word
+    # to jump whole questions to fresh pages, stranding half-blank pages.
+    before = len(doc.paragraphs) if hasattr(doc, "paragraphs") else None
+    for b in blk.get("blocks", []):
+        emit_block(doc, b, theme)
+    if before is not None:
+        for p in doc.paragraphs[before:-1]:
+            if p.text.strip():
+                _keep_with_next(p)
+
+
+def _emit_workspace(doc, blk, theme, *, labeled=False):
+    if labeled and blk.get("label"):
+        _label_para(doc, blk)
+    h = workspace_height(blk, theme)
+    if blk.get("ruled", theme.ruled_default):
+        # Ruled handwriting lines: one bottom-bordered table row per line — the
+        # same border mechanism the number lines use. Paragraph borders (pBdr)
+        # never rendered reliably in Word: property-order sensitive, and
+        # adjacent identically-bordered paragraphs merge into one box.
+        gap = float(theme.answer_gap)
+        n = max(2, int(round(h / gap)))
+        tbl = doc.add_table(rows=n, cols=1)
+        tbl.autofit = False
+        _cant_split(tbl)
+        for row in tbl.rows:
+            row.height = Pt(gap)
+            row.height_rule = WD_ROW_HEIGHT_RULE.AT_LEAST
+            _cell_borders(row.cells[0], ["bottom"], color="C9CFD4", sz="6")
+    else:
+        tbl = doc.add_table(rows=1, cols=1)
+        tbl.rows[0].height = Pt(h)
+        tbl.rows[0].height_rule = WD_ROW_HEIGHT_RULE.AT_LEAST
+        _set_borders(tbl, color="FFFFFF")
+    doc.add_paragraph(style="LC Spacer")
+
+
+def _emit_page_break(doc, blk, theme):
+    doc.add_paragraph().add_run().add_break(WD_BREAK.PAGE)
+
+
+def _emit_table(doc, blk, theme):
+    headers = coerce_headers(blk.get("headers"))
+    rows = coerce_rows(blk.get("rows"))
+    ncols = max(len(headers), max((len(r) for r in rows), default=1), 1)
+    tbl = doc.add_table(rows=0, cols=ncols)
+    _set_borders(tbl, color=theme.safe("border").lstrip("#"))
+    _set_cell_margins(tbl)
+    if headers:
+        hr = tbl.add_row()
+        hr._tr.get_or_add_trPr().append(OxmlElement("w:tblHeader"))
+        for i, h in enumerate(headers):
+            _shade_cell(hr.cells[i])
+            add_md(hr.cells[i].paragraphs[0], str(h).rstrip(": "), bold=True)
+    large = blk.get("display") == "large"
+    for r in rows:
+        tr = tbl.add_row()
+        cells = [str(r[i]) if i < len(r) else "" for i in range(ncols)]
+        # Underscore runs are write-in blanks, not text.
+        cells = ["" if c.strip().strip("_") == "" and "_" in c else c for c in cells]
+        full_blank = not any(c.strip() for c in cells)
+        for i, v in enumerate(cells):
+            p = tr.cells[i].paragraphs[0]
+            add_md(p, v, bold=(large and v.strip() != "")
+                   or (not headers and i == 0 and v.strip() != ""))
+            if large:
+                from docx.enum.text import WD_ALIGN_PARAGRAPH
+                p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+                for run in p.runs:
+                    run.font.size = Pt(18)
+        if any(not c.strip() for c in cells):
+            tr.height = Pt(table_row_height(blk, theme, full_blank=full_blank))
+            tr.height_rule = WD_ROW_HEIGHT_RULE.AT_LEAST
+    _cant_split(tbl)
+    doc.add_paragraph(style="LC Spacer")
+
+
+def _emit_columns(doc, blk, theme):
+    tbl = doc.add_table(rows=1, cols=2)
+    _set_borders(tbl, color="FFFFFF")
+    # A side-by-side comparison is one visual unit — never let Word split the row
+    # across a page boundary (a number line half on each page is unreadable).
+    _cant_split(tbl)
+    for side, cell in (("left", tbl.rows[0].cells[0]), ("right", tbl.rows[0].cells[1])):
+        for b in blk.get(side, []):
+            emit_block(cell, b, theme)
+
+
+def _emit_source_card(doc, blk, theme):
+    head = " · ".join(str(blk.get(k))
+                      for k in ("title", "author", "date", "origin") if blk.get(k))
+    _emit_callout(doc, {"kind": "student-task", "label": head,
+                        "text": blk.get("excerpt") or blk.get("text") or ""}, theme)
+
+
+def _emit_fill_table(doc, blk, theme):
+    headers = coerce_headers(blk.get("headers"))
+    try:
+        cols = max(1, len(headers) or int(blk.get("cols") or 2))
+    except (TypeError, ValueError):
+        cols = 2
+    cols = min(cols, 12)
+    rows_val = blk.get("rows")
+    if isinstance(rows_val, list):
+        # Mixed rows: a non-empty list renders its cells (a worked example);
+        # an empty list [] renders a blank write-in row.
+        rows = []
+        for r in coerce_rows(rows_val[:50]):
+            cells = r[:cols]
+            rows.append(cells + [""] * (cols - len(cells)))
+    else:
+        try:
+            n = int(blk.get("blank_rows") or rows_val or 3)
+        except (TypeError, ValueError):
+            n = 3
+        rows = [[""] * cols for _ in range(min(max(1, n), 50))]
+    fwd = {"headers": headers, "rows": rows}
+    for k in ("row_height_pt", "empty_row_height_pt"):
+        if blk.get(k):
+            fwd[k] = blk[k]
+    _emit_table(doc, fwd, theme)
+
+
+def _cell_borders(cell, sides, color="3A4046", sz="12"):
+    """Per-cell borders (the table-level helper paints every cell the same)."""
+    pr = cell._tc.get_or_add_tcPr()
+    borders = pr.find(qn("w:tcBorders"))
+    if borders is None:
+        borders = OxmlElement("w:tcBorders")
+        pr.append(borders)
+    for side in sides:
+        el = OxmlElement(f"w:{side}")
+        el.set(qn("w:val"), "single")
+        el.set(qn("w:sz"), sz)
+        el.set(qn("w:color"), color)
+        borders.append(el)
+
+
+def _emit_number_line(doc, blk, theme):
+    """A drawn number line, same geometry as the html twin: a horizontal bar with
+    evenly spaced tick marks and the min/max labeled at the ends. Built from a
+    borderless table — the segment cells' bottom borders form the line, their
+    left/right borders form the ticks — so students mark values on it by hand.
+
+    ticks=0 is a distinct "blank line" for student partitioning: the bar and its
+    end labels still draw, but with no tick marks at all, not even at the ends."""
+    try:
+        raw_ticks = None if blk.get("ticks") is None else int(blk.get("ticks"))
+    except (TypeError, ValueError):
+        raw_ticks = None
+    is_blank = raw_ticks == 0
+    ticks = 10 if raw_ticks is None else raw_ticks
+    ticks = min(max(1, ticks), 24)  # one cell per segment; 24 is plenty on paper
+    lo, hi = blk.get("min", 0), blk.get("max", 10)
+    marks = coerce_marks(blk.get("marks"))
+    try:
+        lo_f, hi_f = float(lo), float(hi)
+        span = hi_f - lo_f or 1.0
+    except (TypeError, ValueError):
+        lo_f, hi_f, span = 0.0, float(ticks), float(ticks)
+    eps = abs(span) * 0.002
+    marks = [(v, lab) for v, lab in marks
+             if abs(v - lo_f) > eps and abs(v - hi_f) > eps]
+
+    line_color = theme.safe("text").lstrip("#")
+    rows = 3 if marks else 2
+    # A single segment (ticks==1, or ticks==0 clamped to one) has only one bar but
+    # still needs two independently positioned end labels. A table cell can't hold
+    # two independently aligned runs reliably across docx viewers (a tab stop
+    # inside a merged cell doesn't render everywhere), so we always give the
+    # label row two real grid columns and merge them back into one cell for the
+    # bar/marks rows, which every docx viewer renders correctly.
+    single_segment = ticks == 1
+    cols = 2 if single_segment else ticks
+    tbl = doc.add_table(rows=rows, cols=cols)
+    tbl.autofit = False
+    _cant_split(tbl)
+    # cantSplit stops mid-row breaks; keep-with-next on every paragraph above the
+    # last row stops Word separating the line from its labels between rows.
+    for row in tbl.rows[:-1]:
+        for cell in row.cells:
+            for para in cell.paragraphs:
+                para.paragraph_format.keep_with_next = True
+    r = 0
+    if marks:
+        # A mark row above the line: label + ▼ centered over the nearest segment boundary.
+        mark_row = tbl.rows[0]
+        if single_segment:
+            mark_row.cells[0].merge(mark_row.cells[1])
+        for v, lab in marks:
+            seg = 0 if single_segment else min(ticks - 1, max(0, int(round((v - lo_f) / span * ticks))))
+            p = mark_row.cells[seg].paragraphs[0]
+            if lab:
+                r_lab = p.add_run(str(lab) + " ")
+                r_lab.bold = True
+                r_lab.font.size = Pt(8.5)
+            p.add_run("▼").bold = True
+            p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            p.paragraph_format.space_after = Pt(0)
+        r = 1
+    # The line row: bottom borders draw the bar, left/right borders draw the end
+    # ticks — omitted for a blank line, which shows only the bar and its labels.
+    line = tbl.rows[r]
+    line.height = Pt(22)  # room above the line for student marks
+    line.height_rule = WD_ROW_HEIGHT_RULE.AT_LEAST
+    if single_segment:
+        line_cell = line.cells[0].merge(line.cells[1])
+        sides = ["bottom"] + ([] if is_blank else ["left", "right"])
+        _cell_borders(line_cell, sides, color=line_color)
+        line_cell.paragraphs[0].paragraph_format.space_after = Pt(0)
+    else:
+        for i, cell in enumerate(line.cells):
+            sides = ["bottom", "left"] + (["right"] if i == ticks - 1 else [])
+            _cell_borders(cell, sides, color=line_color)
+            cell.paragraphs[0].paragraph_format.space_after = Pt(0)
+    # The label row: min under the first tick, max under the last — always two
+    # distinct grid cells, even for a single segment (see `cols` above).
+    labels = tbl.rows[r + 1]
+    lp = labels.cells[0].paragraphs[0]
+    add_md(lp, str(lo))
+    lp.paragraph_format.space_after = Pt(0)
+    rp = labels.cells[cols - 1].paragraphs[0]
+    add_md(rp, str(hi))
+    rp.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+    rp.paragraph_format.space_after = Pt(0)
+    doc.add_paragraph(style="LC Spacer")
+
+
+# Adding a block type or text field? Render it in render_lesson_html.py in the
+# same commit — the html and docx renderers must emit the same text.
+_EMITTERS = {
+    "paragraph": _emit_paragraph,
+    "labeled": _emit_labeled,
+    "h2": _emit_heading("LC H2"),
+    "h3": _emit_heading("LC H3"),
+    "instructions": _emit_instructions,
+    "list": _emit_list,
+    "checklist": lambda d, b, t: _emit_list(d, b, t, checklist=True),
+    "callout": _emit_callout,
+    "cards": _emit_cards,
+    "fill_in": _emit_fill_in,
+    "phase_header": _emit_phase_header,
+    "group": _emit_group,
+    "workspace": _emit_workspace,
+    "labeled_box": lambda d, b, t: _emit_workspace(d, b, t, labeled=True),
+    "page_break": _emit_page_break,
+    "table": _emit_table,
+    "columns": _emit_columns,
+    "source_card": _emit_source_card,
+    "fill_table": _emit_fill_table,
+    "number_line": _emit_number_line,
+}
+
+
+def emit_block(doc, blk: dict, theme: Theme):
+    fn = _EMITTERS.get(_btype(blk))
+    if fn is not None:
+        return fn(doc, blk, theme)
+    if blk.get("text"):
+        add_md(doc.add_paragraph(), blk["text"])
+    elif blk.get("items"):
+        for item in blk["items"]:
+            add_md(doc.add_paragraph(style="List Bullet"), item)
+
+
+# ---- document assembly -------------------------------------------------------
+
+def render(data: dict, out_path: str) -> int:
+    data = expand_document(data, data.get("audience", "teacher"))
+    theme = Theme(data.get("theme"))
+    (theme.answer_height, theme.answer_gap,
+     theme.answer_row, theme.ruled_default) = answer_profile(data)
+    theme.student_doc = data.get("audience") == "student"
+
+    doc = Document()
+    for s in doc.sections:
+        s.left_margin = s.right_margin = Inches(0.7)
+        s.top_margin = s.bottom_margin = Inches(0.6)
+    theme.content_width = _content_width(doc)
+    setup_styles(doc, theme)
+
+    hdr = build_header(data)
+    if hdr["eyebrow"]:
+        doc.add_paragraph(hdr["eyebrow"], style="LC Eyebrow")
+    doc.add_paragraph(hdr["title"], style="LC Title")
+    if hdr["meta"]:
+        doc.add_paragraph(hdr["meta"], style="LC Meta")
+    if hdr["name_line"]:
+        p = doc.add_paragraph()
+        add_md(p, hdr["name_line"])
+        p.paragraph_format.space_after = Pt(16)
+
+    for blk in preamble_blocks(data):
+        emit_block(doc, blk, theme)
+
+    for section in data.get("sections", []):
+        h1 = doc.add_paragraph(style="LC H1")
+        h1.paragraph_format.keep_with_next = True
+        h1.add_run(str(section.get("heading", "")).rstrip(": "))
+        for blk in section.get("blocks", []):
+            emit_block(doc, blk, theme)
+
+    if data.get("footer_note"):
+        doc.add_paragraph(str(data["footer_note"]), style="LC Muted")
+
+    doc.save(out_path)
+    # Post-expansion count, so multi-document sources report accurately.
+    return len(data.get("sections", []))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("input", help="lesson JSON file")
+    ap.add_argument("-o", "--output", default="lesson_plan.docx")
+    args = ap.parse_args()
+    data = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    render(data, args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skill-library/k12-lesson-differentiation/scripts/render_lesson_html.py
+++ b/skill-library/k12-lesson-differentiation/scripts/render_lesson_html.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render lesson JSON -> a styled, self-contained HTML preview (the teacher-facing view).
+
+Visual design principles:
+  - Minimal color. Callouts are distinguished by an icon prefix, not background fill, so they
+    survive B+W printing. Student worksheets avoid color entirely.
+  - Horizontal rule above each H1 section; no colored section bars.
+  - Bullets over paragraphs wherever possible.
+  - Shorter student tasks may use a 2-column layout to save pages.
+  - Student worksheets follow: task -> instructions -> reminders -> workspace.
+
+Block types (canonical names; legacy aliases accepted, see ALIASES in lesson_common):
+  paragraph, labeled, list, h2, h3, callout, table, cards, columns, group, page_break,
+  phase_header, fill_in, instructions, workspace, checklist
+
+Usage:
+    python render_lesson_html.py lesson.json -o lesson_preview.html
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from html import escape
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lesson_common import (  # noqa: E402
+    DEFAULT_THEME, Theme, CALLOUT_KINDS,
+    btype as _btype, resolve_callout_kind as _resolve_callout_kind,
+    answer_profile, expand_document, build_header, preamble_blocks, coerce_marks,
+    workspace_height, normalize_text, label_text, label_sep, table_row_height,
+    coerce_headers, coerce_rows,
+)
+
+FILL_IN_SIZES = {"short": "6em", "med": "14em", "long": "100%"}
+
+
+def md(text) -> str:
+    t = escape(normalize_text(text), quote=True)
+    t = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", t)
+    t = re.sub(r"(?<!\*)\*(?!\s)(.+?)(?<!\s)\*(?!\*)", r"<i>\1</i>", t)
+    # Preserve line structure: text fields use \n for meaningful line breaks (sub-parts,
+    # multi-paragraph callouts). Collapsing them produced unreadable prose blobs.
+    t = re.sub(r"[ \t]*\n[ \t]*", "<br>", t)
+    return t
+
+
+def answer_space(blk: dict, theme) -> str:
+    """Open writing space — blank whitespace, or ruled lines for lower-grade prose."""
+    h = workspace_height(blk, theme)
+    if blk.get("ruled", theme.ruled_default):
+        gap = float(theme.answer_gap)
+        n = max(2, int(round(h / gap)))
+        lines = f"<div class=\"ansline\" style=\"height:{gap:g}pt\"></div>" * n
+        return f"<div class=\"ans\">{lines}</div>"
+    return f"<div class=\"ans\" style=\"height:{h:g}pt\"></div>"
+
+
+def css(theme: Theme) -> str:
+    """All styling lives in theme.css (next to this script) so the designer can edit it
+    directly. CSS custom properties carry the few themeable values."""
+    css_path = Path(__file__).resolve().parent / "theme.css"
+    base = css_path.read_text(encoding="utf-8") if css_path.exists() else ""
+    if not base:
+        print(f"warning: {css_path} not found — output will be unstyled", file=sys.stderr)
+    try:
+        title_size = float(theme.raw.get("title_size", DEFAULT_THEME["title_size"]))
+    except (TypeError, ValueError):
+        title_size = DEFAULT_THEME["title_size"]
+    try:
+        body_size = float(theme.raw.get("body_size", DEFAULT_THEME["body_size"]))
+    except (TypeError, ValueError):
+        body_size = DEFAULT_THEME["body_size"]
+    root = (":root{"
+            f"--primary:{theme.safe('primary')};--title-color:{theme.safe('title_color')};"
+            f"--text:{theme.safe('text')};--muted:{theme.safe('muted')};"
+            f"--rule:{theme.safe('rule')};--border:{theme.safe('border')};"
+            f"--title-size:{title_size}pt;--body-size:{body_size}pt"
+            "}")
+    return root + "\n" + base
+
+
+def render_block(blk: dict, theme: Theme) -> str:
+    # Adding a block type or text field? Render it in render_lesson_docx.py in
+    # the same commit — the html and docx renderers must emit the same text.
+    t = _btype(blk)
+    if t == "paragraph":
+        return f"<p>{md(blk.get('text', ''))}</p>"
+    if t == "labeled":
+        lbl = label_text(blk)
+        return f"<p><b>{md(lbl)}{label_sep(lbl)}</b> {md(blk.get('text', ''))}</p>"
+    if t == "h2":
+        return f"<div class=\"h2\">{md(blk.get('text', ''))}</div>"
+    if t == "h3":
+        return f"<div class=\"h3\">{md(blk.get('text', ''))}</div>"
+    if t == "instructions":
+        return f"<p class=\"instr\">{md(blk.get('text', ''))}</p>"
+    if t in ("list", "checklist"):
+        cls = ' class="check"' if t == "checklist" else ""
+        tag = "ol" if blk.get("ordered") else "ul"
+        items = "".join(f"<li>{md(i)}</li>" for i in blk.get("items", []))
+        head = (f"<p class=\"listlabel\"><b>{md(label_text(blk))}</b></p>"
+                if blk.get("label") else "")
+        return f"{head}<{tag}{cls}>{items}</{tag}>"
+    if t == "callout":
+        # Models sometimes write "body"/"content" for the content key — tolerate rather than
+        # silently rendering an empty box.
+        text = blk.get("text") or blk.get("body") or blk.get("content") or ""
+        kind = _resolve_callout_kind(blk)
+        icon, klass = CALLOUT_KINDS[kind]
+        label = label_text(blk)
+        head = (f"<div class=\"co-label\"><span class=\"co-icon\">{icon}</span>"
+                f"<b>{md(label)}</b></div>" if label
+                else f"<div class=\"co-label\"><span class=\"co-icon\">{icon}</span></div>")
+        body = f"<p style=\"margin:0\">{md(text)}</p>" if text else ""
+        return f"<div class=\"co {klass}\">{head}{body}</div>"
+    if t == "cards":
+        items = [c if isinstance(c, dict) else {"title": str(c), "text": ""}
+                 for c in blk.get("items", [])]
+        cards = "".join(
+            "<div class=\"card\">"
+            f"<div class=\"card-title\">{md(c.get('title', ''))}</div>"
+            f"<div class=\"card-body\">{md(c.get('text', ''))}</div></div>"
+            for c in items)
+        return f"<div class=\"cards\">{cards}</div>"
+    if t == "fill_in":
+        size = FILL_IN_SIZES.get(str(blk.get("size", "med")).lower(), FILL_IN_SIZES["med"])
+        line = f"<span class=\"fillin\" style=\"width:{size}\"></span>"
+        if blk.get("label"):
+            return f"<p class=\"fillin-row\"><b>{md(label_text(blk))}:</b> {line}</p>"
+        return f"<p class=\"fillin-row\">{line}</p>"
+    if t == "phase_header":
+        mins = blk.get("minutes")
+        right = f"<span class=\"mins\">{md(mins)} min</span>" if mins is not None else ""
+        return (f"<div class=\"h2 phase\"><span>{md(blk.get('name', ''))}</span>"
+                f"{right}</div>")
+    if t == "group":
+        inner = "".join(render_block(b, theme) for b in blk.get("blocks", []))
+        return f"<div style=\"page-break-inside:avoid\">{inner}</div>"
+    if t == "workspace":
+        return answer_space(blk, theme)
+    if t == "labeled_box":
+        label = md(label_text(blk))
+        head = f"<p class=\"listlabel\"><b>{label}</b></p>" if label else ""
+        return f"{head}{answer_space(blk, theme)}"
+    if t == "page_break":
+        return "<hr class=\"pagebreak\">"
+    if t == "table":
+        headers = coerce_headers(blk.get("headers"))
+        head = ""
+        if headers:
+            head = ("<tr>" + "".join(f"<th>{md(str(h).rstrip(': '))}</th>" for h in headers)
+                    + "</tr>")
+        rows = []
+        for r in coerce_rows(blk.get("rows")):
+            # An underscore run is the model writing "blank to fill in" — render it as a
+            # real blank cell, not literal underscores.
+            r = ["" if str(c).strip().strip("_") == "" and "_" in str(c) else c for c in r]
+            full_blank = not any(str(c).strip() for c in r)
+            row_h = table_row_height(blk, theme, full_blank=full_blank)
+            cells = []
+            for c in r:
+                style = ""
+                if not str(c).strip():  # td height acts as a minimum; the row still grows
+                    style = f" style=\"height:{row_h:g}pt\""
+                cells.append(f"<td{style}>{md(c)}</td>")
+            rows.append("<tr>" + "".join(cells) + "</tr>")
+        classes = [] if headers else ["headless"]
+        if blk.get("display") == "large":
+            classes.append("display-large")
+        klass = f" class=\"{' '.join(classes)}\"" if classes else ""
+        return f"<table{klass}>{head}{''.join(rows)}</table>"
+    if t == "columns":
+        left = "".join(render_block(b, theme) for b in blk.get("left", []))
+        right = "".join(render_block(b, theme) for b in blk.get("right", []))
+        return f"<div class=\"cols\"><div>{left}</div><div>{right}</div></div>"
+    if t == "source_card":
+        bits = " · ".join(md(str(blk.get(k))) for k in ("author", "date", "origin")
+                          if blk.get(k))
+        title = md(blk.get("title", ""))
+        excerpt = md(blk.get("excerpt") or blk.get("text") or "")
+        meta = f"<span class=\"sc-meta\"> — {bits}</span>" if bits else ""
+        return (f"<div class=\"sourcecard\"><div class=\"sc-head\"><b>{title}</b>{meta}</div>"
+                f"<div class=\"sc-body\">{excerpt}</div></div>")
+    if t == "fill_table":
+        headers = coerce_headers(blk.get("headers"))
+        row_h = table_row_height(blk, theme, full_blank=True)
+        head = ("<tr>" + "".join(f"<th>{md(h)}</th>" for h in headers) + "</tr>") if headers else ""
+        try:
+            cols = max(1, len(headers) or int(blk.get("cols") or 2))
+        except (TypeError, ValueError):
+            cols = 2
+        cols = min(cols, 12)
+        rows_val = blk.get("rows")
+        if isinstance(rows_val, list):
+            # Mixed rows: a non-empty list renders its cells (a worked example);
+            # an empty list [] renders a blank write-in row.
+            body = ""
+            for r in coerce_rows(rows_val[:50]):
+                cells = r[:cols]
+                cells += [""] * (cols - len(cells))
+                # Underscore runs are write-in blanks, not text (same rule as `table`,
+                # and as the docx fill_table path which forwards through _emit_table).
+                cells = ["" if str(c).strip().strip("_") == "" and "_" in str(c) else c
+                         for c in cells]
+                tds = "".join(
+                    f"<td>{md(c)}</td>" if str(c).strip()
+                    else f"<td style=\"height:{row_h:g}pt\"></td>" for c in cells)
+                body += f"<tr>{tds}</tr>"
+        else:
+            try:
+                n = int(blk.get("blank_rows") or rows_val or 3)
+            except (TypeError, ValueError):
+                n = 3
+            n = min(max(1, n), 50)
+            body = ("<tr>" + (f"<td style=\"height:{row_h:g}pt\"></td>" * cols) + "</tr>") * n
+        return f"<table>{head}{body}</table>"
+    if t == "number_line":
+        lo, hi = blk.get("min", 0), blk.get("max", 10)
+        try:
+            raw_ticks = None if blk.get("ticks") is None else int(blk.get("ticks"))
+        except (TypeError, ValueError):
+            raw_ticks = None
+        # An explicit 0 means "blank line — students partition it themselves": the
+        # bar and its end labels still draw, but with no tick marks at all.
+        is_blank = raw_ticks == 0
+        ticks = 10 if raw_ticks is None else raw_ticks
+        ticks = min(max(1, ticks), 100)
+        marks = coerce_marks(blk.get("marks"))
+        try:
+            lo_f, hi_f = float(lo), float(hi)
+            span = hi_f - lo_f or 1.0
+        except (TypeError, ValueError):
+            lo_f, hi_f, span = 0.0, float(ticks), float(ticks)
+        eps = abs(span) * 0.002
+        marks = [(v, lab) for v, lab in marks
+                 if abs(v - lo_f) > eps and abs(v - hi_f) > eps]
+        tick_html = "".join(
+            f"<span class=\"nl-tick\" style=\"left:{(i/ticks)*100:.2f}%"
+            + (";border-left:none" if is_blank else "") + "\">"
+            f"<span class=\"nl-lab\">{md(lo if i == 0 else hi if i == ticks else '')}</span></span>"
+            for i in range(ticks + 1))
+        mark_html = "".join(
+            f"<span class=\"nl-mark\" style=\"left:{((v-lo_f)/span)*100:.2f}%\"></span>"
+            + (f"<span class=\"nl-mlab\" style=\"left:{((v-lo_f)/span)*100:.2f}%\">{md(lab)}</span>" if lab else "")
+            for v, lab in marks)
+        return (f"<div class=\"numberline\"><div class=\"nl-bar\">{tick_html}{mark_html}"
+                f"</div></div>")
+    # NEVER dump raw JSON into the page — a printed worksheet with {"type": ...} on it is a
+    # blocking print-safety failure (seen in real model output: "list" and "labeled_box").
+    if blk.get("text"):
+        return f"<p>{md(blk.get('text'))}</p>"
+    if blk.get("items"):
+        return "<ul>" + "".join(f"<li>{md(i)}</li>" for i in blk.get("items", [])) + "</ul>"
+    # Unknown type with no renderable content: emit nothing. (No debug comment — the type
+    # string is model-controlled and could contain "-->" to break out of an HTML comment.)
+    return ""
+
+
+def render(data: dict) -> str:
+    data = expand_document(data, data.get("audience", "teacher"))
+    theme = Theme(data.get("theme"))
+    (theme.answer_height, theme.answer_gap,
+     theme.answer_row, theme.ruled_default) = answer_profile(data)
+    theme.student_doc = data.get("audience") == "student"
+    hdr = build_header(data)
+    out = ["<div class=\"hdr\">"]
+    if hdr["eyebrow"]:
+        out.append(f"<div class=\"eyebrow\">{md(hdr['eyebrow'])}</div>")
+    out.append(f"<div class=\"title\">{md(hdr['title'])}</div>")
+    if hdr["meta"]:
+        out.append(f"<div class=\"meta\">{md(hdr['meta'])}</div>")
+    out.append("</div>")
+    if hdr["name_line"]:
+        out.append(f"<p style=\"margin:6pt 0 22pt\">{md(hdr['name_line'])}</p>")
+
+    for blk in preamble_blocks(data):
+        out.append(render_block(blk, theme))
+
+    LIGHT_TYPES = {"paragraph", "labeled", "list", "checklist", "h2", "h3", "callout",
+                   "instructions"}
+    HEAVY_TYPES = {"group", "workspace", "labeled_box"}
+    for section in data.get("sections", []):
+        h1 = (f"<div class=\"h1\"><span>{md(str(section.get('heading', '')).rstrip(': '))}"
+              "</span></div>")
+        # The section heading + leading light blocks + the first atomic item
+        # (group/workspace) print as one unbreakable unit, so an instructions box never
+        # strands above a page break while its first problem starts the next page.
+        blocks = list(section.get("blocks", []))
+        unit = [h1]
+        glued = 0
+        while blocks and glued < 4 and _btype(blocks[0]) in LIGHT_TYPES:
+            unit.append(render_block(blocks.pop(0), theme))
+            glued += 1
+        if blocks and _btype(blocks[0]) in HEAVY_TYPES:
+            unit.append(render_block(blocks.pop(0), theme))
+        if len(unit) > 1:
+            out.append("<div style=\"page-break-inside:avoid\">" + "".join(unit) + "</div>")
+        else:
+            out.append(h1)
+        for blk in blocks:
+            out.append(render_block(blk, theme))
+
+    if data.get("footer_note"):
+        out.append(f"<div class=\"footer\">{md(data['footer_note'])}</div>")
+
+    title = escape(str(data.get("title", "Lesson Plan")), quote=True)
+    return ("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>" + title
+            + "</title><style>" + css(theme) + "</style></head><body><div class=\"page\">"
+            + "".join(out) + "</div></body></html>")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("input", help="lesson JSON file")
+    ap.add_argument("-o", "--output", default="lesson_preview.html")
+    args = ap.parse_args()
+    data = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    Path(args.output).write_text(render(data), encoding="utf-8")
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skill-library/k12-lesson-differentiation/scripts/theme.css
+++ b/skill-library/k12-lesson-differentiation/scripts/theme.css
@@ -1,0 +1,93 @@
+/* Copyright 2026 Anthropic, PBC
+   Copyright 2026 Learning Commons
+   SPDX-License-Identifier: Apache-2.0 */
+
+/* Lesson artifact stylesheet — designer-editable.
+   :root vars (--primary, --text, --muted, --rule, --border, --title-size, --body-size)
+   are injected by render_lesson_html.css(). Everything else lives here. */
+
+body{font-family:'Helvetica Neue',Arial,sans-serif;color:var(--text);margin:0;background:#fff}
+.page{max-width:7.1in;margin:0 auto;padding:36pt 24pt;font-size:var(--body-size);line-height:1.55}
+
+/* --- header ------------------------------------------------------------ */
+.hdr{margin-bottom:12pt}
+.eyebrow{color:var(--primary);font-size:9pt;font-weight:700;letter-spacing:1.2pt;text-transform:uppercase}
+.title{color:var(--text);font-size:var(--title-size);font-weight:700;line-height:1.2;letter-spacing:-0.3pt;margin-top:6pt}
+.meta{color:var(--muted);font-size:9pt;margin-top:7pt;line-height:1.5}
+
+/* --- headings ---------------------------------------------------------- */
+.h1{font-size:14pt;font-weight:700;letter-spacing:-0.1pt;border-top:1pt solid var(--rule);
+    padding-top:18pt;margin:24pt 0 12pt;page-break-after:avoid}
+.h2{font-size:12pt;font-weight:700;color:var(--primary);margin:16pt 0 8pt;page-break-after:avoid}
+.h2.phase{display:flex;justify-content:space-between;align-items:baseline}
+.h2 .mins{font-weight:400;font-size:9pt;color:var(--muted)}
+.h3{font-size:10.5pt;font-weight:700;margin:12pt 0 6pt;page-break-after:avoid}
+
+/* --- body -------------------------------------------------------------- */
+p{margin:0 0 8pt}
+.listlabel{margin:10pt 0 2pt}
+ul,ol{margin:0 0 10pt;padding-left:20pt}li{margin:0 0 5pt}
+ul.check{list-style:none;padding-left:4pt}ul.check li:before{content:"\2610  "}
+.instr{color:var(--text);margin:8pt 0 10pt}
+
+/* --- callouts (icon-differentiated, B+W-safe) -------------------------- */
+.co{border:1pt solid var(--border);border-radius:6pt;padding:10pt 12pt;margin:6pt 0 12pt;
+    page-break-inside:avoid}
+.co-label{font-size:9.5pt;margin-bottom:4pt;display:flex;gap:6pt;align-items:baseline}
+.co-icon{font-size:11pt;line-height:1}
+.co.special{border-color:#5BB088}
+.co.task{border-color:#9FB8D8}
+.co.tnote{border-color:#E8C98A}
+.co.snote{border-color:#E8C98A}
+
+/* --- tables ------------------------------------------------------------ */
+table{width:100%;border-collapse:separate;border-spacing:0;margin:4pt 0 14pt;
+      font-size:9pt;line-height:1.45;border:0.6pt solid var(--border);border-radius:6pt;
+      overflow:hidden}
+th,td{border-bottom:0.6pt solid var(--border);border-right:0.6pt solid var(--border);
+      padding:7pt 9pt;text-align:left;vertical-align:top}
+th:last-child,td:last-child{border-right:none}
+tr:last-child td{border-bottom:none}
+tr{page-break-inside:avoid}
+th{background:#F6F8F9;font-weight:700}
+table.headless td:first-child{font-weight:600}
+
+/* --- cards ------------------------------------------------------------- */
+.cards{display:flex;gap:12pt;margin:6pt 0 14pt}
+.card{flex:1;border:0.8pt solid var(--border);border-radius:6pt;padding:10pt 12pt;
+      background:#FAFBFB;page-break-inside:avoid}
+.card-title{font-weight:700;font-size:9.5pt;margin-bottom:4pt}
+.card-body{font-size:9pt}
+
+/* --- worksheet primitives --------------------------------------------- */
+.fillin-row{margin:0 0 10pt}
+.fillin{display:inline-block;border-bottom:0.8pt solid var(--text);height:1.1em;vertical-align:baseline}
+.ans{margin:0 0 14pt}
+.ansline{border-bottom:0.7pt solid #C9CFD4}
+.cols{display:flex;gap:24pt}.cols>div{flex:1;min-width:0}
+
+/* --- registry block types (source_card, number_line) -------------------- */
+.sourcecard{border:0.8pt solid var(--border);border-left:3pt solid var(--primary);
+            border-radius:4pt;padding:9pt 12pt;margin:6pt 0 14pt;page-break-inside:avoid}
+.sourcecard .sc-head{font-size:9.5pt;margin-bottom:5pt}
+.sourcecard .sc-meta{color:var(--muted);font-weight:400}
+.sourcecard .sc-body{font-size:9.5pt;line-height:1.55;white-space:pre-wrap}
+.numberline{margin:10pt 0 18pt;padding:0 8pt}
+.numberline .nl-bar{position:relative;height:28pt;border-top:1.5pt solid var(--text);margin-top:14pt}
+.numberline .nl-tick{position:absolute;top:-6pt;width:0;border-left:1pt solid var(--text);height:10pt}
+.numberline .nl-lab{position:absolute;top:11pt;left:0;transform:translateX(-50%);
+                    font-size:8.5pt;white-space:nowrap}
+.numberline .nl-mark{position:absolute;top:-10pt;width:0;height:0;border-left:5pt solid transparent;
+                     border-right:5pt solid transparent;border-top:8pt solid var(--primary);
+                     transform:translateX(-5pt)}
+.numberline .nl-mlab{position:absolute;top:-22pt;left:0;transform:translateX(-50%);
+                     font-size:8.5pt;font-weight:600;white-space:nowrap;color:var(--primary)}
+
+/* --- misc -------------------------------------------------------------- */
+.pagebreak{page-break-after:always;border:none;margin:0;height:0}
+.footer{color:var(--muted);font-size:8pt;margin-top:20pt}
+
+@media print{.page{padding:0}body{background:#fff}}
+
+/* --- large display tables (K-2 word grids, sort cards) ------------------ */
+table.display-large td{font-size:18pt;font-weight:600;text-align:center;padding:10pt 12pt;letter-spacing:0.5pt}

--- a/skill-library/k12-lesson-planning/LICENSE
+++ b/skill-library/k12-lesson-planning/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skill-library/k12-lesson-planning/SKILL.md
+++ b/skill-library/k12-lesson-planning/SKILL.md
@@ -1,0 +1,471 @@
+---
+name: k12-lesson-planning
+category: 教学辅导
+description: >-
+  为 K-12 教师从零创建一节课的完整教学包:教案 + 学生用材料 + 课堂观察表,覆盖数学、语文/英语(ELA)、科学、社会与历史四科,并按学科加载专属参考,产出可编辑的 Word 文档。在向老师追问年级、学科、课题、课标或时长之前就应加载本技能。若同一次请求还要分层/分级材料,仍算一次备课,由本技能在教学包内一并产出,不要再调用 k12-lesson-differentiation。不适用于批改、评分量规、作业反馈、出测验或课标检索(直接回答即可);改造已有教案请用 k12-lesson-differentiation。触发词:备课, 写教案, 教案设计, 写一节课, 课时计划, 单元计划, 迷你课, 我明天要讲, 我在教, 学生用材料, 课堂观察表; lesson plan, mini-lesson, unit plan, daily plan.
+license: Complete terms in LICENSE
+---
+
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# K-12 Lesson Planning
+
+Produces a teacher-ready, standards-aligned lesson plan + student-facing materials + teacher
+observation template as editable Word documents in a single output turn, rendered from one material-source JSON via
+bundled scripts. Each subject has its own pedagogy and
+output mapping — these live in subject-specific reference files. This skill routes to the
+right one. Works with or without the Learning Commons Knowledge Graph.
+
+"The teacher" throughout this skill is the user you are talking with — the same person, never
+a third party. "Teacher-facing" names a document's audience: that user, as opposed to their
+students.
+
+---
+
+## Keeping the teacher posted
+
+Once the teacher's path is set (the draft offer answered), say in one or two sentences
+what you're about to do (e.g. *"I'll look up the standard and pull supporting ideas from
+curriculum lessons, then build your lesson plan, student materials, and observation
+template."*).
+
+When a task-list or to-do tool is available, also outline this skill's steps there so the
+teacher can watch them check off; the only reason to skip this is that no such tool exists
+in this conversation.
+
+Teacher language only — name what the teacher is getting, never tool names, file names,
+"JSON", or "rendering".
+
+---
+
+## Step 0 — Route (silent, before anything else)
+
+1. **Subject.** Determine the subject of the requested lesson from the prompt and any prior
+   conversation:
+
+   - **math** — arithmetic, fractions, geometry, algebra, calculus, statistics, CCSS-M codes, IM (Illustrative Mathematics)
+   - **ela** — reading, writing, phonics, literature, comprehension, vocabulary, CCSS-ELA codes (RL/RI/RF/W/L)
+   - **science** — phenomena, NGSS Performance Expectations, biology/chemistry/physics/earth science, OpenSciEd
+   - **social_studies** — history, civics, geography, economics, C3 inquiry arc, state social-studies standards
+
+   Then read the matching reference file NOW:
+
+   - math → `references/math.md`
+   - ELA → `references/ela.md`
+   - science → `references/science.md`
+   - social studies → `references/social_studies.md`
+
+   **Loading the matching reference file is mandatory.** Drafting a lesson without first
+   reading the subject reference is a critical failure. The reference file carries the
+   complete subject-specific instructions: clarify priorities, curriculum branching,
+   grade-band structures, section structure, non-negotiables, and the lesson.json mapping.
+   Treat the loaded reference as your full skill instructions for this turn. If the subject
+   is genuinely ambiguous or the prompt spans multiple subjects, ask about it
+   in Step 1.
+
+2. **Curriculum.** If the teacher names or implies a curriculum (Illustrative Mathematics,
+   OpenSciEd, …), the subject file's curriculum branch covers it — each subject
+   file carries its curriculum's structures and language inline (curriculum and subject are
+   1:1: IM→math, OpenSciEd→science). If they use a curriculum the subject
+   file doesn't cover, follow its "no curriculum named" path and do not fake
+   curriculum-specific terminology.
+3. **Connector.** Check whether the Learning Commons Knowledge Graph tools (e.g.
+   `find_standard_statement`) are available in this conversation. This decides which path
+   Step 2 takes. The skill is fully functional without the connector.
+
+---
+
+## Step 1 — Clarify
+
+Read the subject file first — its clarify section defines the priorities and defaults. We
+usually ask 0–2 clarifying questions — your judgment on what's relevant; the subject
+file's priorities rank which missing answers matter most. Apply the defaults silently for
+everything you don't ask about.
+
+The **draft offer** (see *Step 4 — The draft offer* below) travels with this message's questions
+as its own separate question — output logistics, not lesson content, so it doesn't count
+toward the 0–2. When nothing needs clarifying, the offer is asked on its own.
+
+---
+
+## Step 2 — Ground in standards
+
+**If the LC Knowledge Graph is connected:** follow the subject's section in
+`references/learning-commons-kg.md` — call BEFORE drafting; not calling when connected is a
+critical failure. Extract only what each call specifies, then proceed directly to Step 3 — do
+not summarize findings in chat.
+
+**If not connected:** draft from best knowledge and add this footer to the lesson plan:
+*"Generated without the Learning Commons Knowledge Graph. Standards and misconceptions reflect
+general best practice."* Do not invent KG citations or attribute content to curriculum
+materials you have not seen.
+
+---
+
+## Step 3 — Build the lesson
+
+Follow the subject file's build section: curriculum branching, grade-band structure, section
+structure, and non-negotiables. Respect the **Copyright guardrail** below — never reproduce
+curriculum student-facing text verbatim.
+
+---
+
+## Copyright guardrail
+
+Always write original content. KG curriculum materials inform structure, scope, text
+selection, phenomenon selection, problem context, and lesson-arc design only — never
+reproduce student-facing text, teacher notes, comprehension questions, investigation
+prompts, discussion questions, activity narratives, or problem contexts verbatim from KG
+curriculum materials.
+
+If the loaded reference identifies a source curriculum (e.g., IM for math, OpenSciEd for science) and the teacher is not curriculum-confirmed for it, never name
+that curriculum anywhere in the output or in any chat message — not in headers, footnotes,
+rationale sections, facilitation notes, or your message presenting the artifacts. The KG
+data informs the design without being cited.
+
+---
+
+## Step 4 — The draft offer
+
+The teacher gets the choice of a fast draft before the build. The offer is
+asked the same way as the clarify questions — through the structured question tool when
+one is available, in chat otherwise — as its own separate question, batched with Step 1's
+questions when there are any and asked on its own when there aren't.
+
+- Question: *Should I go ahead and build the full classroom-ready packet (lesson plan + student materials, as
+  editable Word docs), or do you want to see a quick draft first?*
+- Options: **Go ahead and build it** · **Quick draft first** — the lesson at a glance,
+  right here in chat
+
+**The full packet is the default.** Declining, not answering, or anything like "proceed
+with your defaults" runs Steps 2–3 and goes straight to Step 5; the draft happens only on
+a clear yes.
+
+**The draft (on a yes) is built on Steps 2–3, never instead of them.** Run Step 2 in
+full — every KG call, exactly as written — and Step 3 before sketching anything. A draft
+sketched without the Step 2 grounding is a critical failure, the same failure as skipping
+the KG on the full build. Then present the lesson in chat — the draft is chat text only;
+rendering happens at Step 5 once the teacher approves. Show:
+
+- one line naming the grade, topic, and the standard the lesson is anchored to (code plus
+  a gist of ten words or fewer);
+- a summary of at most 3 sentences (what students do and why it works for this class);
+- the sequence as one bullet per phase (name, minutes, one line of what happens);
+- the student work at a glance — the actual tasks students will do, enough for the
+  teacher to skim and judge coverage;
+- what the lesson assumes students already know — the prerequisite skills or key
+  vocabulary in play — so the teacher can catch a mismatch with where their class is;
+- the exit ticket
+
+The draft borrows its names from the documents it previews — phases, tasks, tiers,
+and sections are called what the plan will call them.
+
+Afterwards, ask what's next — a structured question, two options:
+
+- **Make changes** — adjust any part of the draft
+- **Create the materials** — lesson plan, student materials, and observation template, as
+  editable Word documents
+
+Apply change requests to the draft in chat and re-present it — changes are quick at this
+stage. Step 5 runs in the turn the teacher gives the go-ahead ("Create the materials",
+"proceed with your defaults", or similar).
+
+---
+
+## Step 5 — Output (one turn)
+
+Runs immediately when the teacher chose the full packet, or in the turn the draft is
+approved.
+
+The artifacts are rendered by bundled scripts from **one material-source `lesson.json`**. The JSON
+holds a `shared` block (content registered once) and a `documents[]` array (each document
+authored as free-form `sections`). A section's `heading` renders as a large title directly
+above its blocks; a block's `label` renders as a bold lead-in on the block itself. A label
+that repeats its section's heading prints the same words twice in a row — labels carry what
+the heading doesn't (the task's name belongs in one of them, not both). You
+compose every page — the lesson plan, the student
+materials, the observation template, and any others the lesson needs (e.g. a source packet)
+— directly in `documents[]`. Anything that appears on more than one page is registered once
+in `shared` under a key you choose and pulled into each document with
+`{"type": "from_shared", "key": …}`, so the pages cannot drift apart.
+
+Never write layout code, never re-type lesson content into another format, and never edit a
+generated document directly — every change goes into `lesson.json` and is re-rendered
+(re-rendering is instant). **Do not open, cat, head, or grep the renderer scripts** — their
+behavior is fully specified by the commands and output paths in §5a–5d, and
+`references/example_lesson.json` is the complete schema. Reading script source tells you
+nothing this file doesn't already state.
+
+**Plain language with the teacher.** The machinery above is invisible to the teacher: never
+mention JSON, HTML, schemas, scripts, rendering, file names (`lesson.json`), or code in any
+teacher-facing message — and never link or name the `.html` files the render command also
+writes. Say *"Here's your lesson plan — the student materials and observation template are on
+their way"*, not *"I've rendered lesson.json"*. The only format word in your prose is
+"Word document". This
+applies to every turn: presenting artifacts, the satisfaction ask, revision summaries, and
+error messages (if generation fails, say the documents couldn't be created — not that a
+script or JSON failed).
+
+**Density rules — hard requirements for every document.** Every document is clear, brief,
+and easy to skim. Include what a teacher needs to teach it; leave out what merely
+demonstrates rigor. Headings use sentence case. Structure beats prose:
+
+- A `paragraph` or `labeled` block is at most 3 sentences. Longer → split it, bullet it, or
+  table it.
+- Write like a colleague's note: plain, direct sentences built from commas and periods.
+- Bullets are fragments — one idea each, ≤ ~15 words; never chain clauses with semicolons.
+- Parallel variants (per-group supports, per-phase differentiation, tiered look-fors) go in
+  ONE `table` block — rows = phases or features, columns = variants, ≤ ~25 words per cell —
+  never back-to-back multi-sentence paragraphs.
+- A callout marks the few moments a teacher must not miss — a warning ("do not resolve the
+  debate yet"), a collect-before-moving-on, the one make-or-break move of a phase. A page
+  where everything is boxed highlights nothing: a phase reads as plain script with at most
+  one or two callouts. Teacher asides (watch-fors, confer prompts) are `labeled` or
+  `instructions` blocks.
+- Each instruction lives in exactly one place. A phase's opening prose and its blocks divide
+  the work between them — the prose sets up, the blocks carry the content; neither repeats
+  the other.
+- Quote the standard verbatim exactly once (the target-standard callout, from `shared`).
+  Everywhere else — prerequisite grounding, forward connections — reference by code plus a
+  gist of ten words or fewer; never re-paste full standard text.
+- A section that runs past about half a page of continuous prose must be restructured
+  (table, bullets, or split into two sections) before rendering.
+
+**Everything matches — hard requirements for every document.** A teacher trusts the package
+because every part agrees with every other part:
+
+- The materials list and the phases agree exactly: every listed item is used by a named
+  phase, and every counted set matches its enumeration ("Picture cards, 18" lists 18 words).
+- **Classroom-ready:** the lesson runs on what the teacher already holds. Every Materials
+  item is a page this package ships, equipment the classroom has, or a sourced resource
+  with its access path stated — exact title and source, a link when you could confirm one.
+  Anything harder to get than that stays out of the lesson unless the teacher steered
+  toward it. A printable the lesson depends on ships with the package — as lesson pages
+  when the document set expresses it, or as its own file in the format that renders it
+  best (5e).
+- A task worded in two places (plan's "Students see" and the student page) uses identical
+  wording in both.
+- Student tasks match the skill the standard names, in both directions. Decoding, spelling,
+  and writing skills happen on paper — students read and write real words on a student page.
+  Listening and speaking skills get spoken, pointed, sorted, drawn, or circled responses.
+  The lesson's scope statement binds every task that follows it.
+- Scripts and worked examples are final say-aloud text: every step decided before it lands
+  on the page, exactly what the teacher says.
+- Exit-ticket sort buckets partition the answers: each example response fits exactly one
+  bucket, and equivalent forms of one answer (17 + 24 = ? and 24 + 17 = ?) sit in the same
+  bucket together.
+- An answer space mirrors its ask: rows match the count requested, and every box sits under
+  a prompt naming what goes in it.
+- Number pairs inside a sentence are plain text ("2 → 10, 5 → 25"); a table is always its
+  own block.
+
+**Reading level and workload.** Student-facing text reads at the students' reading level —
+which the teacher may state separately from the grade ("my 6th graders read at a 2nd–4th
+grade level" means grade-6 content carried in sentences a 2nd–4th grade reader can read:
+short sentences, everyday words, one instruction at a time). Size the student work to the
+class period: a typical student finishes the worksheet in the minutes its phase allows.
+Say "home language," not a specific language, and print translations only into a language
+the teacher has named.
+
+**Sentence supports** are plain text where students write: a starter to begin from
+("One central idea is…") or a fill-in frame with blanks sized for the student's handwriting.
+A support helps the student start, not answer — it never pre-fills what the task asks for.
+Place each one on the specific task whose writing move is hardest — including the
+explain-why beside a math equation — never one bank copied across problems. K-2 students
+and multilingual learners get a support on every task that asks for composed sentences.
+Tasks that take only a number, a single word, or a drawing need none.
+
+**Spell out framework names** in every teacher-facing document — *Science and Engineering
+Practice*, not bare *SEP* — a teacher should never need to look up an acronym.
+
+**Document integrity.** Every document is finished prose a teacher hands out or works from:
+
+- Every in-document reference points at something that exists in the package: "jot it in the
+  table below" means that table is on the page; an exit ticket collected separately prints as
+  its own piece; a reference table uses the same numbers as the problems it supports.
+- Materials and the lesson match both ways: each listed item is used somewhere in the
+  lesson, every item any section sends students to — phases and extensions alike — appears
+  in Materials, and anything students read is printed in the package or named by its exact
+  title. Offers and pointers to the chat conversation stay out
+  of documents entirely.
+- Lessons are light on materials: the default kit is what every classroom has (board,
+  projector, paper) plus the pages this lesson ships. A separate printable or manipulative
+  earns its place only when the activity genuinely needs it — and the same thinking work on
+  the worksheet usually serves. When a printable earns it (cards, mats, a template), ship it
+  with the package (5e picks the format); equipment a classroom owns is simply listed.
+- Phase minutes include the transitions they cause (handing out, regrouping, collecting), at
+  a pace real students of this grade manage, and the phases sum to exactly the stated
+  period — transition time lives inside the phases, never as invisible buffer.
+- Teacher notes read as finished sentences. A predicted error names one specific wrong answer
+  a real student would produce.
+- Verify every computation by working it — answer keys, worked examples, and any quantitative
+  chain the lesson builds on (an energy pyramid's levels, a ratio table's entries, a coin
+  total) produce the numbers the materials state.
+
+### 5a. Write the complete `lesson.json` (same turn)
+
+Write ONE `lesson.json` with two top-level keys: `shared` and `documents`.
+
+**`shared` is a content registry.** It always carries the lesson identity — `grade`,
+`subject`, `duration`, `standard_code`, `standard_text` (and `curriculum`,
+`prerequisite_standard`, `smps[]` when applicable). Beyond that, register any content that
+appears on more than one page under a key you choose: a problem as `p1`, a source as
+`stamp_act_petition`, a data set as `prices_table`. A key's
+value can be a string, a single block, a list of blocks, or a faceted object
+`{teacher: …, student: …, stimulus: [blocks]}`. On a **student** page, only the `student`
+facet (after any `stimulus` blocks) renders — a `student` of `null` means nothing prints
+there, which is how oral or teacher-led tasks stay off the worksheet. On a **teacher** page,
+both facets render: the teacher facet as plain script, then the student facet as one
+"Students see" line, so the teacher reads their own script and the exact prompt
+students will work from. A teacher facet written as a list of strings renders one move per
+line — the glanceable form for any script with more than two moves — and since the student
+text prints right beside it, the script points to it ("read the story in the box aloud")
+rather than quoting it again. Apart from `standard` (which assembles `standard_code` +
+`standard_text` into the target-standard callout), key names carry no special rendering — a
+vocabulary list, a misconceptions table, an exit-ticket sort are blocks you compose yourself
+(see `references/example_lesson.json` for the patterns).
+
+**`documents[]` is where you compose each page.** Each entry is a full page:
+`{id, audience: teacher|student, eyebrow, title, meta?, theme?, sections[{heading, blocks[]}]}`.
+Include at minimum:
+
+- `id: "lesson_plan"` (`audience: "teacher"`) — the subject file's section structure.
+- `id: "observation_template"` (`audience: "teacher"`) — how-to-use, look-fors,
+  misconceptions, a `fill_table` for student notes, and the exit-ticket sort.
+- `id: "student_materials"` (`audience: "student"`) — **only when students hold a printed
+  page.** A K-2 phonics or oral lesson may have none; a source-heavy lesson may have this AND
+  a separate `id: "source_packet"`. The subject file's *Student page layout* gives the
+  default skeleton; adapt it to the lesson. If the teacher asked for leveled/tiered student
+  materials, label them Group A / B / C (A = below, B = at, C = above grade level) — level
+  wording stays in the teacher-facing documents.
+
+Inside any document, pull registered content with `{"type": "from_shared", "key": "…"}` —
+the same key on two pages renders the same content (faceted by audience). Adding
+`"label": "1"` to a `from_shared` block renders the pulled text as a numbered item on one
+line. Within a single document, pull each key once (a reference table, an exit-ticket
+protocol, a word list appears in one section only). Content that appears on only one page
+can be written inline.
+
+**Schema** — sufficient on its own; do not read any other file for the schema:
+
+```
+shared:
+  grade, subject, duration, standard_code, standard_text          (required identity)
+  curriculum?, prerequisite_standard?, smps[]?
+  <any key you choose>: string
+                      | block | block[]
+                      | {teacher: …, student: … or null, stimulus?: block[]}
+  (only `standard` is special — it assembles standard_code+standard_text)
+documents[]: {id, audience: teacher|student, eyebrow, title, meta?, theme?,
+              sections[]: {heading, color?, blocks[]}}
+block types:
+  {type: from_shared, key}
+  {type: paragraph, text} | {type: labeled, label, text}
+  {type: callout, kind: special|student-task|teacher-note|student-note, label, text}
+  {type: h2|h3, text} | {type: list, label?, ordered?, items[]}
+  {type: phase_header, name, minutes} | {type: cards, items[{title, text}]}
+  {type: table|data_table, headers[]?, rows[[]]}
+  {type: fill_table, headers[], blank_rows: int, row_height_pt?}
+  {type: number_line, min, max, ticks?, marks[]?}
+  {type: source_card, title, author?, date?, origin?, excerpt}
+  {type: answer_box, height_pt?, ruled?} | {type: page_break}
+  {type: group, blocks[]} | {type: columns, left[], right[]}
+```
+
+`references/example_lesson.json` is a filled-in worked example. Keep writing tight; no emoji
+in JSON content. The density rules above are hard requirements for every text field.
+Print-safety: never markdown pipe tables (use `table`/`data_table`); for number lines use
+the `number_line` block, not a digit string. The renderer cannot draw images — anything the
+teacher displays (a video, photo, projected image, chart) lives in the lesson plan: name it
+in Materials and in the phase script that uses it. A student page carries only what is
+printed on it.
+
+**Which block when** — pick by what the content *is*, not how it should look:
+
+| Block | Use it for |
+|---|---|
+| `callout` `kind: special` | The one anchoring fact per artifact — the target standard. Typically once. |
+| `callout` `kind: student-task` | Any task students do: anchor task, exit ticket prompt, a practice problem shown in the plan. |
+| `callout` `kind: teacher-note` | An aside the teacher reads but does not say aloud: "don't resolve yet", conferring moves, a watch-for. |
+| `list` `ordered: true` | A numbered sequence — the problem set, procedure steps. Unordered otherwise. |
+| `list` with `label` | A titled enumeration — several discrete items under one label. |
+| `h2` | Sub-sections inside a section — the lesson-sequence phases use `phase_header`, which renders as h2 with minutes; the `minutes` across all phase headers should sum to `shared.duration`. |
+| `h3` | A title above one block (a table, a list group, the look-fors). |
+| `cards` | 2–4 parallel items of roughly equal length — exit-ticket sort buckets, tier summaries. Never for long or unbalanced items; use a `list` for those. |
+| `table` (no `headers`) | Term/definition pairs, label/value reference rows. |
+| `table` / `data_table` with `headers` | Real tabular data with column labels (misconceptions, scaffolds, the data set students analyze). `display: "large"` renders cells in big centered type — a word grid young students point to and read. |
+| `fill_table` | An organizer students write into — observation log, comparison grid, evidence collector. `rows` as a count gives blank rows; `rows` as a list mixes filled and blank — `[["cap","cape"], [], []]` shows a worked first row, then write-in space, and `[["Shell", "", ""]]` gives a labeled row with blank cells students write in (say what goes in the blank — a ✓, yes/no, a word — in the instruction line above). |
+| `number_line` | A drawn number line (`min`, `max`, `ticks`, optional `marks`). `ticks` omitted defaults to 10 evenly spaced segments; `ticks: 0` draws a bare line with only the `min`/`max` end labels and no tick marks, for students to partition themselves. |
+| `source_card` | A primary or secondary source excerpt students read: title/author/date + the excerpt text. |
+| `answer_box` | Writing space after a task. With no `height_pt` it sizes itself to the grade band (K-2 ~200pt, 3-5 ~150pt, 6-8 ~130pt, 9-12 ~115pt). K-5 boxes draw ruled handwriting lines except in math, which defaults to open space; `ruled: true` draws lines at any grade — the surface for answers of composed sentences — and `ruled: false` gives open space for drawing or model-sketching. A task answered in a `fill_table` or on a `number_line` already has its surface. |
+| `group` | Keeps a task's prompt, stimulus, supports, and answer box together so a page break never separates them. |
+
+### 5b. Render every Word document — one command, same turn
+
+```bash
+bash scripts/render_all.sh lesson.json "$OUTPUT_DIR"
+```
+
+This writes one editable `.docx` per `documents[]` entry, named by `id` (e.g.
+`$OUTPUT_DIR/lesson_plan.docx`, `student_materials.docx`, `observation_template.docx`,
+`source_packet.docx`), plus `.html` and `lesson.json` working files. Render straight into
+`$OUTPUT_DIR` and leave everything the script writes in place — later revision turns
+re-render from the working files even though the teacher only sees the Word documents. Then list `$OUTPUT_DIR`
+and confirm every document has both its `.docx` and `.html`; if either is missing or tiny,
+rerun the script. Present the Word documents to the teacher together — attach the lesson plan
+last so it lands on top (chat surfaces stack newest-first). If there is no `student_materials`
+document, say so plainly ("This lesson is oral, so there's no student handout — students will
+work with …"). If the script errors, fix `lesson.json` (it is almost always malformed JSON)
+and rerun. If file generation fails entirely, say so clearly — do not silently fall back to a
+chat-only delivery.
+
+### 5c. The satisfaction ask + iteration options (every output turn)
+
+End the turn with EXACTLY ONE closing message that does three things, in this order:
+
+1. **If Materials names equipment the classroom has that a paper version can stand in
+   for** — coins, blocks, dice, a hundred chart — lead with a bolded offer to print it:
+   *"**This lesson uses base-ten blocks — want me to make a printable set in case
+   yours are short?**"* Anything whose content this lesson wrote — word cards, a
+   source excerpt, a sorting mat with this lesson's categories — already ships with
+   the package.
+2. Asks whether the teacher is satisfied with **every artifact produced** or wants changes —
+   e.g. *"Take a look at the lesson plan, student materials, and observation template — anything
+   you'd like me to adjust?"* Do not skip the ask.
+3. Offers 3–4 high-leverage, **specific** iteration options customized to the subject and
+   topic. Do not write "let me know if you want changes" — that's a non-offer. For example,
+   for a 3–5 ELA reading comprehension lesson: *"Would you like to (1) add more scaffolds for
+   English learners, (2) differentiate by proficiency level, or (3) adapt to be specific to
+   your state standards?"*
+
+### 5d. Revisions — one edit, every artifact stays in sync
+
+Make **targeted edits to `lesson.json`**, then re-render every document (instant). Rules that
+keep the artifacts consistent:
+
+- If the change touches content registered in `shared` (a problem, a source, the exit ticket,
+  vocabulary, look-fors, the phenomenon/context/numbers), edit it **in `shared`** — every
+  document that pulls that key updates automatically.
+- **Consistency sweep after any context/number/task change:** after editing `shared`, re-read
+  every prose block in every `documents[]` entry and update every sentence that still mentions
+  the old context, names, or numbers. When you are done, no document may reference the
+  replaced content anywhere — stale prose is the most common consistency failure.
+- A change aimed at one document (e.g. "more workspace on the worksheet", "add a column to the
+  observation grid") goes in that document's `sections` — never by forking a `shared` key into
+  two variants.
+- Styling: `theme` fields (`primary`, `title_size`, `body_size`) apply to every artifact.
+  Artifacts use minimal color so they print cleanly in black-and-white; do not set
+  per-section or per-phase colors.
+
+### 5e. Supplementary artifacts in their best format
+
+The `lesson.json` pipeline is for the lesson's document set: pages a student or teacher
+reads or writes on. An artifact whose value depends on its form — exact card
+dimensions for cutting, poster-scale type — belongs outside it, as its own file in
+whatever format produces the best version (e.g. a print-ready PDF). Your judgment
+picks the format; source any shared content from `shared` so pages can't drift, and name
+the file in Materials like any other page.

--- a/skill-library/k12-lesson-planning/references/NOTICE
+++ b/skill-library/k12-lesson-planning/references/NOTICE
@@ -1,0 +1,3 @@
+© 2010 National Governors Association Center for Best Practices and Council of Chief State School Officers. All rights reserved.
+
+The Common Core State Standards included in these reference files are used under the public license available at: https://www.thecorestandards.org/public-license/

--- a/skill-library/k12-lesson-planning/references/ela.md
+++ b/skill-library/k12-lesson-planning/references/ela.md
@@ -1,0 +1,227 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# ELA — lesson pedagogy
+
+Loaded by `k12-lesson-planning` when the subject is **ELA**.
+
+## Clarify
+
+Before asking anything, assess the following from all available conversation signals:
+
+**1. State detection:** Scan the conversation for any state signal — teacher mentions a state name, uses state-specific codes (TEKS, SOL, OAS, CA-CCSS, etc.), or says "I teach in [state]." If found, store as state = [state name] and pass it as jurisdiction in the KG standard lookup. Update the default standard framework to match.
+
+**2. Grade band.** Determine from grade level which band applies:
+- **K–2**: foundational literacy — phonics/decoding OR read-aloud/comprehension (infer from standard; RF standards = phonics lesson; RL/RI standards = comprehension lesson)
+- **3–5**: transitional comprehension
+- **6–8**: literary and rhetorical analysis
+- **9–12**: sophisticated analysis and argument
+
+**3. Anchor text.** Note whether the teacher has specified a text. If not, select one from training knowledge appropriate to the grade and standard — or draw from the KG lesson-materials call (see learning-commons-kg.md). Flag your own selection in Section 1 as [suggested].
+
+The anchor text's Materials line says where the text comes from, so the teacher can put
+it in front of students. Public-domain text ships with the package. Copyrighted text
+is cited — title, author, date, source — and the teacher provides copies; say so in chat
+as well. Include a URL only after confirming it resolves; otherwise the citation stands
+on its own. Example: *"Ain't I a Woman?" — Sojourner Truth, 1851 — public domain, ships
+on the student page; full text: https://www.nps.gov/articles/sojourner-truth.htm
+(confirmed).*
+
+When key information is missing, ask. Priority: (1) grade level if missing, (2) topic or text if missing, (3) lesson type for K–2 if standard doesn't clarify, (4) state if not inferrable. Infer everything else. Defaults applied silently: 45–60 min (K–2: allow 45 min), universal access design, CCSS (overridden by the detected state's framework when State Detection finds one).
+
+---
+
+## Standards grounding
+
+Follow **Step 2 — Ground in standards** in SKILL.md: if the Learning Commons Knowledge Graph
+is connected, use the ELA section of `references/learning-commons-kg.md`; if not,
+proceed from best knowledge and add the disclaimer footer.
+
+## Build the lesson
+
+**For all lessons**
+Include at least one visual scaffold that appears concretely on the student page — a
+`fill_table` organizer or an annotation key — registered in `shared`
+and pulled via `from_shared` so the same scaffold
+appears in the lesson plan with the teacher-facing rationale beside it.
+
+Be sure that overall timing and timing for each section is realistic - do not overload the lesson.
+
+---
+
+### Grade band — apply before drafting
+
+Grade band is the primary structural branch. Determine from grade level and apply the matching structure.
+
+---
+
+#### K–2: Foundational Literacy
+
+Determine lesson type from the target standard:
+- **RF standards** (Foundational Skills) → **Lesson Type A: Phonics/Decoding**
+- **RL/RI standards** (Reading Literature / Informational) → **Lesson Type B: Comprehension via Read-Aloud**
+
+Both types share a brief phonics review warm-up; they differ in primary focus.
+
+**Lesson Type A — Phonics/Decoding (RF standards)**
+
+Student-page word work renders as `display: "large"` table grids — big type a child points to
+and reads — never as paragraph runs of words. Word lists for a pattern contain only that
+pattern plus graphemes already taught; read each word aloud to confirm every letter behaves
+as taught. The exit ticket has the child read 3–4 target-pattern words aloud to the teacher
+(include one contrast word, e.g. short-a among a_e); dictation words are spoken by the
+teacher and never printed on the child's ticket.
+
+Match the lesson's scope to the request: a single-pattern introduction ("a lesson on
+magic-e") is a focused 30–40 minute lesson — warm-up on the prerequisite sound, teach the
+pattern, guided practice, independent practice, exit ticket — covering ONE pattern (a_e
+alone, with the others as later lessons). When the teacher names a whole category
+("r-controlled vowels"), the lesson covers the category's distinct sounds — ar, or, and
+er/ir/ur treated as one sound, since they are. The full block below is for when the teacher asks
+for their complete literacy block.
+
+The cited standard matches the skill taught: a hearing/blending lesson (oral, no print)
+cites the phonological-awareness standard family (e.g. RF.2), a decoding/spelling lesson
+cites phonics (RF.3) — a lesson whose scope says "oral identification only" never carries a
+decode-words standard.
+
+Full literacy block (60–80 min, when the teacher asks for their whole block): a typical arc
+is Phonological Awareness (oral only, no print) → Phonics (explicit phoneme-grapheme mapping;
+decode and spell together; real and nonsense words) → Decodable Practice (connected text
+using only patterns already taught plus known high-frequency words) → Read-Aloud (complex,
+content-rich text — nonfiction at least half the time; oral text-dependent questions) →
+Vocabulary & Discussion (2 Tier 2 words) → Shared Writing (co-construct 1–2 sentences) →
+Exit Ticket (one word-reading item + one word-spelling item on the target pattern).
+
+**Lesson Type B — Comprehension via Read-Aloud (RL/RI standards)**
+
+A typical arc: Phonics Warm-Up (5 min, brief review) → Read-Aloud (teacher reads the anchor
+text aloud, stopping at planned points for oral text-dependent questions) → Text-Dependent
+Discussion (oral think-pair-share; questions progress from general understanding → key
+details → vocabulary → simple inference; every student responds) → Vocabulary (2 Tier 2
+words with definition, context, examples) → Shared Writing (co-construct a written response
+using the target words) → Exit Ticket (one oral or simple written comprehension question).
+
+**Non-negotiables for K–2:** no three-cueing (no picture, context, or first-letter guessing
+to identify words); decodable text for phonics practice, not leveled or predictable text;
+read-aloud is instructional — complex, content-rich text chosen deliberately.
+
+---
+
+#### Grades 3–5: Transitional Comprehension
+
+A typical arc — scale it to the request: Launch (activate prior knowledge with one focused
+prompt; let students grapple with the text fresh) → Close Reading (anchor text at grade-level
+complexity, no leveling; first read for gist, second read with an assigned annotation
+purpose) → Discussion (all students write before speaking — Think-Write-Pair-Share; questions
+progress from general understanding → key details → vocabulary/structure → author's craft) →
+Vocabulary (2 Tier 2 words with text context; students use them in the writing task) →
+Writing Task (text-dependent: "Using evidence from paragraphs ___ and ___, explain how the
+author shows…"; opinion in grades 3–4, argument with evidence in grade 5) → Exit Ticket (one
+text-dependent question requiring inference or craft analysis).
+
+**Non-negotiables for 3–5:** complex text for all students — scaffold access through
+re-reading, discussion, and vocabulary, never an easier substitute; text-dependent questions
+only; write before speaking in every discussion.
+
+---
+
+#### Grades 6–8: Literary and Rhetorical Analysis
+
+A typical arc — scale it to the request: Launch (compelling question; brief unshared
+quick-write students revisit at the end) → Close Reading (annotate with an assigned
+analytical lens — claim development, craft moves, evidence for the central idea; partner
+annotation comparison) → Structured Discussion (Think-Write-Pair-Share into whole-class
+discussion moving from literal comprehension to analysis; fishbowl or Socratic Seminar for
+grade 8 or strong groups; debrief discussion quality, not just content) → Vocabulary & Craft
+(1–2 Tier 2 words plus one craft focus — students analyze effect, not just identify) →
+Writing Task (claim + evidence + reasoning; model the structure in 6–7; counterclaim by
+grade 8) → Formative Check (return to the Launch quick-write: how has your thinking
+changed, and what evidence would you cite now?).
+
+**Non-negotiables for 6–8:** analysis, not summary — the task requires an arguable claim the
+text must be cited to support; pair a literary text with an informational source where
+possible; counterclaim in argument by grade 8.
+
+---
+
+#### Grades 9–12: Rhetorical Sophistication and Sustained Argument
+
+A typical arc — scale it to the request: Launch (a precise, genuinely arguable question;
+students write independently, no discussion yet) → Close Reading (annotate for a specific
+analytical lens; multiple reads with different purposes if the passage is short; keep the
+complexity — it's the point) → Academic Discussion (student-to-student; teacher probes, does
+not direct; Socratic Seminar references specific passages by line; debrief content and
+discussion quality) → Craft & Language (one precision craft move; students analyze effect and
+intent) → Writing Task (sustained analytical or argumentative response: arguable claim +
+textual evidence + analysis; counterclaim in argument) → Formative Check (students assess
+their own opening argument: what evidence would you add or revise?).
+
+**Non-negotiables for 9–12:** analysis of *how* and *why*, not just *what* — effect on a
+specific audience in a specific rhetorical context; full texts at full difficulty (no
+excerpting around hard passages, no summaries in place of originals, no pre-explaining);
+counterclaim by grade 11, and rhetorical analysis attends to audience, purpose, and context.
+
+---
+
+### Section structure — all grade bands
+
+1. **At a glance** — standard verbatim in a `special` callout (the ONE verbatim quote — everywhere else standards go by code + a short gist); a one-line lesson arc naming the phases with minutes so the period's shape is visible before any detail; anchor text (title + genre + Lexile if known, or [suggested] flag); materials list — name each item plainly (e.g. "Picture cards, 18")
+2. **Learning goal** — Big Idea (enduring understanding, 1 sentence tied to the text and unit); SWBAT bullets drawn from KG learning components (learning-commons-kg.md, ELA call 2), naming specific sub-skills; Prerequisite (prior standard by code + gist + 1 sentence on prior knowledge assumed)
+3. **Vocabulary & anticipated challenges** — 2–3 Tier 2 target words with definitions and text context; 3 misconceptions specific to this text and task, drawn from the KG or training knowledge, each formatted: *What students do* / *Why it happens* / *Teacher move*
+4. **Lesson sequence** — phases per grade band above; in every phase where students work (reading, word work, writing, sorting): 3+ look-fors each naming the specific student behavior, why it matters for the standard, and what to do; in every discussion phase: specific text-dependent prompts (not generic)
+5. **Design notes** — last section, after the exit ticket: 2–3 elements to keep intact when adapting, each with a brief reason grounded in the research (Science of Reading for K–2 phonics; text complexity for 3–12), including the lesson's central representation or routine and its one-sentence why.
+
+→ **Section structure complete. Proceed to the draft (when the teacher chose one) or Step 5.**
+
+## Exit ticket guidance
+
+The exit ticket is the last phase in Lesson Sequence (`from_shared:exit_ticket` under its phase header). One item targeting the hardest inference or application the standard requires. K-2 phonics: word-reading + word-spelling. K-2 comprehension: oral or simple written check. 3-12: text-dependent question requiring evidence; 6-12 may instead use a return-to-the-Launch-quick-write self-assessment. Three sort buckets (Got it / Almost there / Needs re-teaching).
+
+---
+
+## Writing lesson.json — ELA mapping
+
+When you reach Step 5 (Output) in SKILL.md, register ELA content in `shared` and compose
+`documents[]` like this:
+
+- `shared.subject`: `"ELA"`.
+- The anchor text or shared writing prompt as `shared.anchor_task`:
+  `{teacher: <how to introduce/read it aloud>, student: <the task as the student reads it,
+  or null when the launch is purely oral>}`.
+- The anchor text itself (if reproduced) as its own key — e.g. `shared.passage`:
+  `{type: "source_card", title, author, excerpt}`. If the text is teacher-supplied or
+  copyrighted, don't reproduce it — the lesson plan names it (title, author, where it lives)
+  in Materials and the phase that uses it.
+- Each text-dependent question / writing task as `shared.q1`..`qN`:
+  `{student: <prompt>, teacher?: <what a strong answer cites>}`.
+- `shared.exit_ticket`: `{student: <prompt>, teacher?: <collection note>}`. The sort
+  criteria are a `cards` block you place in the lesson plan after pulling the exit
+  ticket (see `example_lesson.json`).
+- `shared.vocabulary`, `shared.misconceptions`, `shared.look_fors` as in the SKILL.md schema.
+
+**Which documents to emit.** A K-2 phonemic-awareness or oral-language lesson (RF.*.2,
+RF.*.3 phonics warm-ups, listening-comprehension) often has **no `student_materials`
+document** — students hold response cards or nothing. Say so in the lesson plan's Materials
+line and in your message to the teacher. For 3–12 reading/writing lessons, emit
+`student_materials`; if the anchor text is reproduced, also emit a `source_packet` document
+containing just `from_shared:passage`.
+
+**Student page layout** (when emitted) — start from this and adapt:
+
+```
+sections:
+  "Before you read"        from_shared:anchor_task ; answer_box if a written prediction
+  "Text"                   from_shared:passage   (omit when the text isn't reproduced)
+  "Read and respond"       for each question k:
+                             group[ {type: from_shared, key: qk, label: "k"},
+                                    answer_box ]
+                           page_break
+  "<exit heading, kid-facing>"     group[ from_shared:exit_ticket, answer_box ]
+```
+
+**Observation template layout** matches the math layout in `references/math.md`.
+

--- a/skill-library/k12-lesson-planning/references/example_lesson.json
+++ b/skill-library/k12-lesson-planning/references/example_lesson.json
@@ -1,0 +1,668 @@
+{
+  "shared": {
+    "grade": "Grade 6",
+    "subject": "Mathematics",
+    "duration": 50,
+    "standard_code": "6.RP.A.2",
+    "standard_text": "Understand the concept of a unit rate a/b associated with a ratio a:b with b ≠ 0, and use rate language in the context of a ratio relationship.",
+    "anchor_task": {
+      "teacher": [
+        "Put the two deals from the task below on the board; keep the question covered.",
+        "Gut vote, then turn-and-talk: write one math question that would settle it.",
+        "Do not resolve yet. Collect questions and amplify any version of 'How much is 1 bottle?'"
+      ],
+      "student": {
+        "type": "callout",
+        "kind": "student-task",
+        "label": "Try this together",
+        "text": "Two stores sell bottled water. Store A: 2 bottles for $3.00. Store B: 4 bottles for $5.00. Circle the better deal, then write one math question that would settle it for sure."
+      }
+    },
+    "showdown_prices": {
+      "type": "data_table",
+      "headers": [
+        "Item",
+        "FreshMart",
+        "ValueGro"
+      ],
+      "rows": [
+        [
+          "Granola bars",
+          "6 bars for $3.00",
+          "8 bars for $3.60"
+        ],
+        [
+          "Juice",
+          "4 bottles for $6.00",
+          "5 bottles for $8.00"
+        ],
+        [
+          "Rice",
+          "2-lb bag for $3.50",
+          "5-lb bag for $8.00"
+        ],
+        [
+          "Cheese sticks",
+          "3 sticks for $2.00",
+          "5 sticks for $3.50"
+        ],
+        [
+          "Apples",
+          "—",
+          "4 lb for $6.00"
+        ]
+      ]
+    },
+    "p1": {
+      "student": "**Granola bars.** Find the price per bar at each store. Which store wins?"
+    },
+    "p2": {
+      "student": "**Juice.** Find the price per bottle at each store. Which store wins?"
+    },
+    "p3": {
+      "student": "**Rice.** Tomas says FreshMart wins because $3.50 is less money. Do you agree? Use unit prices to back up your answer.",
+      "teacher": "The trap item. It catches lowest-sticker-price thinking; watch for total-only comparisons."
+    },
+    "p4": {
+      "student": "**Cheese sticks.** Find the price per stick at each store. (Stuck? Try thinking in cents.) Which store wins?",
+      "teacher": "Uneven division. Offer the cents conversion if a pair stalls."
+    },
+    "p5": {
+      "student": "**Apples.** Find both unit rates: dollars per pound AND pounds per dollar. Which one would help a shopper on a budget, and what does the other one tell you?"
+    },
+    "vocabulary": {
+      "type": "table",
+      "rows": [
+        [
+          "**Ratio**",
+          "A comparison of two quantities, written a:b."
+        ],
+        [
+          "**Rate**",
+          "A ratio comparing quantities in different units, like dollars and bottles."
+        ],
+        [
+          "**Unit rate**",
+          "The amount of one quantity for exactly 1 of the other."
+        ],
+        [
+          "**Unit price**",
+          "A unit rate for money: the cost of 1 item or 1 unit of measure."
+        ],
+        [
+          "**Per**",
+          "For each 1."
+        ]
+      ]
+    },
+    "misconceptions": {
+      "type": "table",
+      "headers": [
+        "What students do",
+        "Why it happens",
+        "Teacher move"
+      ],
+      "rows": [
+        [
+          "Writes a group rate ('$3.60 per 2 packs') as a unit price.",
+          "'Per' isn't anchored to 'for exactly 1' yet.",
+          "Ask: how much for exactly 1? Point to the 1 row of a ratio table."
+        ],
+        [
+          "Picks the lowest sticker price as the best deal.",
+          "Compares one quantity, ignores how much it buys.",
+          "Ask how much each price buys; compare for the same amount."
+        ],
+        [
+          "Stalls when division is uneven (3 sticks for $2.00).",
+          "Expects whole-number answers; shaky fraction-as-division.",
+          "Convert to cents, or scale the ratio down by friendly numbers."
+        ]
+      ]
+    },
+    "look_fors": {
+      "type": "list",
+      "items": [
+        "**Divides to find the price per 1**: efficient. *Ask what the quotient means; share second in Discuss.*",
+        "**Scales a ratio table down to 1**: a correct alternate path. *Share first in Discuss; connect to the divider's shortcut.*",
+        "**Compares only totals or counts**: the core misconception. *Ask: how much does each price buy?*",
+        "**Stalls on uneven division (item 4)**: a fraction issue, not a ratio issue. *Offer the cents card.*"
+      ]
+    },
+    "exit_ticket": {
+      "teacher": "Collect on a half-sheet. The trap mirrors Rice: agreeing with Maya means comparing totals, not unit prices.",
+      "student": {
+        "type": "callout",
+        "kind": "student-task",
+        "label": "Exit ticket",
+        "text": "Store A sells a 4-bag pack of popcorn for $5.00. Store B sells a 3-bag pack for $4.20. Maya says Store B is the better deal because $4.20 is less money. Find the price per bag at each store. Who is right, and why? Use the word 'per' in your answer."
+      }
+    },
+    "exit_sort": {
+      "type": "cards",
+      "items": [
+        {
+          "title": "Got it",
+          "text": "Both unit prices correct ($1.25 and $1.40 per bag), picks Store A, and explains using per-1 language."
+        },
+        {
+          "title": "Almost there",
+          "text": "Divides to find a price per bag (right method) but makes an arithmetic slip or finds only one unit price; conclusion follows their numbers."
+        },
+        {
+          "title": "Needs re-teaching",
+          "text": "Agrees with Maya by comparing totals ($4.20 < $5.00) or compares bag counts, without finding any price per bag."
+        }
+      ]
+    },
+    "hint_cards": {
+      "type": "cards",
+      "items": [
+        {
+          "title": "Start here",
+          "text": "What does exactly 1 cost? Try price ÷ how many."
+        },
+        {
+          "title": "Ratio table",
+          "text": "Write the deal as a row: items | price. Divide both by the number of items to get the 1 row."
+        },
+        {
+          "title": "Cents card",
+          "text": "Uneven division? Switch to cents. $3.00 for 4 erasers → 300 ÷ 4 = 75 cents each."
+        },
+        {
+          "title": "Say it with per",
+          "text": "Your answer is a price for exactly 1: \"____ per ____.\""
+        }
+      ]
+    }
+  },
+  "documents": [
+    {
+      "id": "lesson_plan",
+      "audience": "teacher",
+      "eyebrow": "Grade 6 · Mathematics · Ratios and Rates",
+      "title": "Unit Rates: Grocery Store Showdown",
+      "meta": "Grade 6 · 50 minutes · 6.RP.A.2",
+      "sections": [
+        {
+          "heading": "At a glance",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "standard"
+            },
+            {
+              "type": "labeled",
+              "label": "In plain terms",
+              "text": "Students turn a price for several items into a price for one item, and use it to compare."
+            },
+            {
+              "type": "labeled",
+              "label": "Lesson arc",
+              "text": "Warm-up 6 min → Mini-lesson 7 → Explore 15 → Discuss 10 → Synthesize 5 → Exit ticket 7 (50 min total)"
+            },
+            {
+              "type": "labeled",
+              "label": "Goal",
+              "text": "Students compare prices by finding the cost of 1, and can say why unit rates settle any better-deal question."
+            },
+            {
+              "type": "callout",
+              "kind": "teacher-note",
+              "label": "Grade-level boundary",
+              "text": "Grade 6 unit rates stay non-complex: every price here divides to money or a simple fraction."
+            },
+            {
+              "type": "list",
+              "label": "Materials",
+              "items": [
+                "Projector or anchor chart",
+                "Showdown handout (1 per pair)",
+                "Hint cards, 4, cut apart — 1 set per table",
+                "Whiteboards"
+              ]
+            },
+            {
+              "type": "list",
+              "label": "Mathematical practices",
+              "items": [
+                "Mathematical Practice 2: Reason abstractly and quantitatively",
+                "Mathematical Practice 6: Attend to precision"
+              ]
+            }
+          ]
+        },
+        {
+          "heading": "Learning goal",
+          "blocks": [
+            {
+              "type": "labeled",
+              "label": "Big idea",
+              "text": "A unit rate makes two deals comparable: both are priced for exactly 1."
+            },
+            {
+              "type": "list",
+              "label": "Students will be able to",
+              "items": [
+                "Write a ratio a:b as a unit rate a/b",
+                "Find unit rates from real-world ratios",
+                "Use rate language: per, for each 1"
+              ]
+            },
+            {
+              "type": "labeled",
+              "label": "Prerequisites",
+              "text": "6.RP.A.1: students can already read and write ratios; today turns those ratios into per-1 prices. The cents hint card leans on 5.NF.B.3."
+            }
+          ]
+        },
+        {
+          "heading": "Vocabulary & anticipated challenges",
+          "blocks": [
+            {
+              "type": "h3",
+              "text": "Key terms"
+            },
+            {
+              "type": "from_shared",
+              "key": "vocabulary"
+            },
+            {
+              "type": "h3",
+              "text": "Anticipated challenges"
+            },
+            {
+              "type": "from_shared",
+              "key": "misconceptions"
+            }
+          ]
+        },
+        {
+          "heading": "Lesson sequence",
+          "blocks": [
+            {
+              "type": "phase_header",
+              "name": "Warm-up: Which deal?",
+              "minutes": 6
+            },
+            {
+              "type": "from_shared",
+              "key": "anchor_task"
+            },
+            {
+              "type": "phase_header",
+              "name": "Mini-lesson: Direct instruction",
+              "minutes": 7
+            },
+            {
+              "type": "list",
+              "items": [
+                "Define ratio, rate, unit rate, unit price, per on the anchor chart",
+                "Model the water deals in a ratio table: $3.00 : 2 → divide by 2 → $1.50 : 1",
+                "Shortcut: unit price = price ÷ quantity ($5.00 ÷ 4 = $1.25 per bottle); resolve the vote",
+                "Whiteboard check: 5 markers for $4.00. Price per marker? ($0.80)"
+              ]
+            },
+            {
+              "type": "phase_header",
+              "name": "Explore: Grocery store showdown",
+              "minutes": 15
+            },
+            {
+              "type": "paragraph",
+              "text": "Pairs work the five Showdown items. Every answer uses 'per'. Hint cards sit face-down on each table."
+            },
+            {
+              "type": "labeled",
+              "label": "Coverage",
+              "text": "straightforward division → 1-2; lowest-price trap → 3; uneven division → 4; dual unit rates → 5; the exit ticket re-tests the trap."
+            },
+            {
+              "type": "from_shared",
+              "key": "showdown_prices"
+            },
+            {
+              "type": "labeled",
+              "label": "What each problem tests",
+              "text": "unit price (baseline): Problems 1–2 · totals-vs-unit-price trap: Problem 3 · uneven division: Problem 4 · best-buy justification: Problem 5 · the trap again with fresh numbers: Exit Ticket"
+            },
+            {
+              "type": "from_shared",
+              "key": "p1",
+              "label": "1"
+            },
+            {
+              "type": "from_shared",
+              "key": "p2",
+              "label": "2"
+            },
+            {
+              "type": "from_shared",
+              "key": "p3",
+              "label": "3"
+            },
+            {
+              "type": "from_shared",
+              "key": "p4",
+              "label": "4"
+            },
+            {
+              "type": "from_shared",
+              "key": "p5",
+              "label": "5"
+            },
+            {
+              "type": "h3",
+              "text": "While you circulate"
+            },
+            {
+              "type": "from_shared",
+              "key": "look_fors"
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Scaffold",
+                "When",
+                "What it looks like"
+              ],
+              "rows": [
+                [
+                  "Cents conversion",
+                  "Uneven division (item 4)",
+                  "$2.00 = 200¢; 200 ÷ 3 ≈ 67¢ per stick"
+                ],
+                [
+                  "Ratio-table build-down",
+                  "No path to 1",
+                  "Divide both columns by friendly numbers until the count hits 1"
+                ],
+                [
+                  "Fraction-as-division card",
+                  "2 ÷ 3 ≠ 2/3 in their head",
+                  "a ÷ b = a/b, so $2.00 ÷ 3 = 2/3 dollar per stick"
+                ]
+              ]
+            },
+            {
+              "type": "phase_header",
+              "name": "Discuss: Strategy Compare",
+              "minutes": 10
+            },
+            {
+              "type": "paragraph",
+              "text": "Pairs swap answers for items 3-4 with a neighboring pair, agree or disagree. Then whole-class: sequence a ratio-table scaler first, a divider second, and connect the two."
+            },
+            {
+              "type": "list",
+              "label": "Discourse questions",
+              "items": [
+                "Where does the 1 live in each strategy?",
+                "Why did the $3.50 rice bag lose, even though it costs less?",
+                "Two unit rates describe the apples. What does each tell you?"
+              ]
+            },
+            {
+              "type": "phase_header",
+              "name": "Synthesize",
+              "minutes": 5
+            },
+            {
+              "type": "paragraph",
+              "text": "On the anchor chart, record each item as given ratio → rate per 1. Land it: unit rates compare because both deals are priced for exactly 1."
+            },
+            {
+              "type": "phase_header",
+              "name": "Exit Ticket",
+              "minutes": 7
+            },
+            {
+              "type": "from_shared",
+              "key": "exit_ticket"
+            },
+            {
+              "type": "h3",
+              "text": "Sort student work"
+            },
+            {
+              "type": "from_shared",
+              "key": "exit_sort"
+            }
+          ]
+        },
+        {
+          "heading": "Design notes",
+          "blocks": [
+            {
+              "type": "labeled",
+              "label": "Cap the mini-lesson at 7 minutes",
+              "text": "If direct instruction grows, Explore and Discuss shrink, and the thinking transfers back to you."
+            },
+            {
+              "type": "labeled",
+              "label": "Keep the traps",
+              "text": "Item 3 and the exit ticket are the only items that catch 'cheapest sticker = best deal'. Without them every student looks proficient."
+            },
+            {
+              "type": "labeled",
+              "label": "Protect the 10-minute Discuss",
+              "text": "Connecting the ratio table to the division shortcut is where 'per 1' consolidates."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "student_materials",
+      "audience": "student",
+      "eyebrow": "Grade 6 Mathematics · Student Materials",
+      "title": "Grocery Store Showdown",
+      "meta": "Name: ____________________    Date: ____________    Partner: ____________________",
+      "theme": {
+        "body_size": 11.5
+      },
+      "sections": [
+        {
+          "heading": "Warm up together",
+          "blocks": [
+            {
+              "type": "group",
+              "blocks": [
+                {
+                  "type": "from_shared",
+                  "key": "anchor_task"
+                },
+                {
+                  "type": "answer_box"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "heading": "Showdown: find the price for 1",
+          "blocks": [
+            {
+              "type": "callout",
+              "kind": "student-note",
+              "label": "Remember",
+              "text": "Use the word **per** in every answer. *Per* means *for each 1*."
+            },
+            {
+              "type": "from_shared",
+              "key": "showdown_prices"
+            },
+            {
+              "type": "group",
+              "blocks": [
+                {
+                  "type": "from_shared",
+                  "key": "p1",
+                  "label": "1"
+                },
+                {
+                  "type": "answer_box"
+                }
+              ]
+            },
+            {
+              "type": "group",
+              "blocks": [
+                {
+                  "type": "from_shared",
+                  "key": "p2",
+                  "label": "2"
+                },
+                {
+                  "type": "answer_box"
+                }
+              ]
+            },
+            {
+              "type": "group",
+              "blocks": [
+                {
+                  "type": "from_shared",
+                  "key": "p3",
+                  "label": "3"
+                },
+                {
+                  "type": "paragraph",
+                  "text": "I (agree / disagree) with Tomas, because one pound of rice costs $__________ at FreshMart and $__________ at ValueGro."
+                },
+                {
+                  "type": "answer_box",
+                  "ruled": true
+                }
+              ]
+            },
+            {
+              "type": "group",
+              "blocks": [
+                {
+                  "type": "from_shared",
+                  "key": "p4",
+                  "label": "4"
+                },
+                {
+                  "type": "answer_box"
+                }
+              ]
+            },
+            {
+              "type": "group",
+              "blocks": [
+                {
+                  "type": "from_shared",
+                  "key": "p5",
+                  "label": "5"
+                },
+                {
+                  "type": "answer_box"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "heading": "Show what you know",
+          "blocks": [
+            {
+              "type": "group",
+              "blocks": [
+                {
+                  "type": "from_shared",
+                  "key": "exit_ticket"
+                },
+                {
+                  "type": "answer_box",
+                  "ruled": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "hint_cards",
+      "audience": "student",
+      "eyebrow": "Grade 6 Mathematics · Hint Cards",
+      "title": "Stuck? Pick a hint card",
+      "sections": [
+        {
+          "heading": "Hint cards",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "Take one card only when your pair is stuck."
+            },
+            {
+              "type": "from_shared",
+              "key": "hint_cards"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "observation_template",
+      "audience": "teacher",
+      "eyebrow": "Grade 6 Mathematics · Observation Template",
+      "title": "Grocery Store Showdown Observation",
+      "sections": [
+        {
+          "heading": "How to use this",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "Circulate during Explore. Tally what you see in the Look-fors grid; star one ratio-table scaler and one divider to share in Discuss. After class, sort exit tickets into the three piles below."
+            }
+          ]
+        },
+        {
+          "heading": "Look-fors",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "look_fors"
+            },
+            {
+              "type": "fill_table",
+              "headers": [
+                "Student",
+                "Strategy seen",
+                "Next step"
+              ],
+              "blank_rows": 8,
+              "row_height_pt": 26
+            }
+          ]
+        },
+        {
+          "heading": "Anticipated challenges",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "misconceptions"
+            }
+          ]
+        },
+        {
+          "heading": "Exit-ticket sort",
+          "blocks": [
+            {
+              "type": "from_shared",
+              "key": "exit_ticket"
+            },
+            {
+              "type": "from_shared",
+              "key": "exit_sort"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/skill-library/k12-lesson-planning/references/learning-commons-kg.md
+++ b/skill-library/k12-lesson-planning/references/learning-commons-kg.md
@@ -1,0 +1,108 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Learning Commons Knowledge Graph — call sequences
+
+Used by `k12-lesson-planning` Step 2 **only when the LC Knowledge Graph tools are available**.
+If they are not, skip this file entirely (SKILL.md Step 2 has the fallback).
+Each section below is the call sequence for one subject. Calling the KG when connected is
+mandatory; not calling it is a critical failure.
+
+## Resolving the standard (all subjects)
+
+Resolve the standard with `find_standard_statement`, passing `academicSubject` and `jurisdiction` (the U.S. state) when they're known:
+
+- **A code is provided** (named in the source lesson or by the teacher): search by code — `find_standard_statement(code=<code>, academicSubject="<subject>")`. A code search matches both the code itself and everything beneath it (prefix match): a leaf like `3.NF.A.1` returns just that standard, while a parent like `2.OA` returns `2.OA` plus all `2.OA.*`. **If it returns nothing**, the code's format probably doesn't match the graph's — fall back to keyword search (below); its results come back with real `code` values that reveal the correct format, which you can use to retry the code search.
+- **No code provided**: start with keyword search — `find_standard_statement(keywords=["<word or phrase>", "<word or phrase>", …], academicSubject="<subject>")`. `keywords` is a **list** of topic words/phrases; a standard matches if ANY of them appears in its description. Pick the best-matching standard from the returned `standards` array — its `code` can seed a follow-up code search for related standards (e.g. its parent prefix to pull the whole family).
+
+When a returned standard has children, they come back in its `subStandards` array — use whichever is most relevant to the user's request, the standard itself or one of its sub-standards.
+
+**Cap at 3 search attempts total.** Results from the wrong grade band or course count as
+a miss — a high-school US History request answered with elementary codes means the search
+terms missed, so spend the remaining attempts with different keywords (the course name,
+the era, the standard family) rather than falling back early. If no usable standard after
+3 calls to `find_standard_statement`, stop searching — proceed with the best-matching
+standard from training knowledge for the grade and topic, and add the partial-coverage
+footer to the lesson plan. Never call `find_curriculum_lessons` to locate a standard.
+
+From the chosen standard, extract: the verbatim statement text, its `code`, and `caseIdentifierUUID` (store — required for all subsequent calls). When the statement has lettered sub-parts, the verbatim quote is the sub-part(s) this lesson targets, with the parent named by code.
+
+## Mathematics
+
+Call BEFORE drafting. Not calling when connected is a critical failure. Make all calls, extract only what is specified below, then proceed directly to Step 3 — KG findings surface in chat only through the draft's one-line standard read-back, never as a results summary.
+
+The only cross-call data dependencies are the standard's `caseIdentifierUUID` (used by steps 2–5) and the `lessonIdentifier` that `find_curriculum_lessons` returns (used by `find_materials_for_lesson`). So: resolve the standard, then issue the step 2–4 calls and `find_curriculum_lessons` — each with its full parameters as specified below — as one parallel batch, then fetch materials.
+
+**Available tools:** `find_standard_statement`, `find_standards_progression_from_standard`, `find_misconceptions_for_standard`, `find_learning_components_from_standard`, `list_standards_for_mathematical_practice`, `find_curriculum_lessons`, `find_materials_for_lesson`.
+
+1. **Standard**: Resolve the standard per *Resolving the standard* above with `academicSubject="Mathematics"`. Use the verbatim statement text exactly as written in the lesson plan's standard callout.
+
+2. **Prerequisite**: Call `find_standards_progression_from_standard(caseIdentifierUUID, direction="backward")` → extract: the single primary prerequisite standard, verbatim. Use in the LEARNING GOAL section. Non-negotiable — not naming the prior standard is a critical failure.
+
+3. **Learning components**: Call `find_learning_components_from_standard(caseIdentifierUUID)` → extract: up to 5 sub-skill descriptions (unknown positions, problem types). Use directly as SWBAT bullets and as look-for row labels in the observation template. Discard the rest.
+
+4. **Misconceptions**: Call `find_misconceptions_for_standard(caseIdentifierUUID, subject="Mathematics")` → extract: the 3 most relevant misconceptions. For each keep only the student behavior and the teacher move, rewritten in your own words. If no results, draft 3 from training knowledge.
+
+5. **Lesson materials**: Call `find_curriculum_lessons(caseIdentifierUUID=<uuid from step 1>, author="Illustrative Mathematics")` → select the single most relevant lesson (grade-level match first). Call `find_materials_for_lesson(lessonIdentifier, materialSource=["lesson", "activity"])` for the lesson overview and activity materials in one call → extract: (a) activity names and sequence, (b) problem types and unknown positions addressed, (c) any explicit discourse moves. Discard full activity narratives and student-facing text — these must not be reproduced verbatim.
+
+6. **SMPs**: Choose 2–3 from training knowledge. No KG call needed.
+
+**Curriculum-terminology check (if not IM-confirmed):** Before proceeding, scan your working notes and verify they contain zero mentions of "Illustrative Mathematics," "IM," any MLR name (MLR 1–8), "Compare and Connect," "Stronger and Clearer Each Time," or any IM lesson/activity title. Remove any that remain — a teacher who has not confirmed IM must not receive IM-specific terminology in the lesson or in chat (the same rule as SKILL.md's Copyright guardrail).
+
+**If KG not connected:** draft from best knowledge; add footer: *"Generated without the Learning Commons Knowledge Graph. Standards and misconceptions reflect general best practice."*
+
+→ **KG phase complete. Proceed immediately to Step 3.**
+
+---
+
+## ELA
+
+Call BEFORE drafting. Not calling when connected is a critical failure. Make all calls in sequence, extract only what is specified, then proceed directly to Step 3 — KG findings surface in chat only through the draft's one-line standard read-back, never as a results summary.
+
+**Available tools:** `find_standard_statement`, `find_learning_components_from_standard`
+
+1. **Standard**: Resolve the standard per *Resolving the standard* above with `academicSubject="English Language Arts"` (codes look like RL.4.3, RI.6.6, RF.1.2b, W.8.1, L.5.4). Use the verbatim statement text exactly as written in Section 1.
+
+2. **Learning components**: Call `find_learning_components_from_standard(caseIdentifierUUID)` → extract: up to 5 sub-skill descriptions if available. Use directly as SWBAT bullets in Section 2. Discard the rest.
+
+3. **Text complexity check**: If an anchor text is identified (from teacher or KG), note whether its Lexile falls in the correct CCSS grade-band range. Flag if outside band.
+
+**If KG not connected:** draft from best knowledge; add footer: *"Generated without the Learning Commons Knowledge Graph. Standards and misconceptions reflect general best practice."*
+
+→ **KG phase complete. Proceed immediately to Step 3.**
+
+---
+
+## Science
+
+Call BEFORE drafting. Not calling when connected is a critical failure. Make all calls in sequence, extract only what is specified, then proceed directly to Step 3 — KG findings surface in chat only through the draft's one-line standard read-back, never as a results summary.
+
+**Available tools:** `find_standard_statement`, `find_curriculum_lessons`, `find_materials_for_lesson`.
+
+Note: `find_learning_components_from_standard` and `find_standards_progression_from_standard` do **not** return data for science standards — do not call them.
+
+1. **Standard**: Resolve the standard per *Resolving the standard* above with `academicSubject="Science"` (the code is an NGSS Performance Expectation, e.g. `MS-LS2-3`, `3-LS1-1`, `HS-PS1-1`). Use the verbatim statement text exactly as written in Section 1.
+
+2. **OpenSciEd unit and lesson**: Call `find_curriculum_lessons(caseIdentifierUUID=<uuid from step 1>, author="OpenSciEd")` → select the single most relevant lesson (grade-level match first, then closest topic match). Call `find_materials_for_lesson(lessonIdentifier, materialSource=["activity"])` → extract: (a) unit anchoring phenomenon; (b) unit driving question; (c) this lesson's investigative phenomenon or question; (d) this lesson's position in the unit storyline; (e) which SEP(s) and CCC(s) are foregrounded; (f) any specific routines or activity structures used. **Do NOT reproduce OSE student-facing text, investigation prompts, or discussion questions verbatim — these must be rewritten as original content.**
+
+**If KG not connected:** draft from best knowledge; add footer: *"Generated without the Learning Commons Knowledge Graph. Standards and OpenSciEd alignment reflect general best practice."*
+
+→ **KG phase complete. Proceed immediately to Step 3.**
+
+---
+
+## Social Studies
+
+
+Use the KG to find the authoritative standard statement for this topic and grade band. This grounds the lesson in the actual standard rather than a paraphrase.
+
+1. **Standard**: Resolve the standard per *Resolving the standard* above with `academicSubject="Social Studies"` and `jurisdiction="<state>"` (required — Social Studies standards live only under the state, never `Multi-State`). Use the verbatim statement text in the lesson plan header under `**Standard:**`, and let it anchor the compelling question and formative task.
+
+**If no standard is found:** align the lesson to the most relevant state specific standard from training knowledge, and note briefly: *"Standard lookup not available for [state/code]."* Do not halt generation.
+
+→ **KG phase complete. Proceed immediately to Step 3.**
+
+---

--- a/skill-library/k12-lesson-planning/references/math.md
+++ b/skill-library/k12-lesson-planning/references/math.md
@@ -1,0 +1,161 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Math — lesson pedagogy
+
+Loaded by `k12-lesson-planning` when the subject is **math**.
+
+## Clarify
+Before asking anything, assess the following from all available conversation signals:
+
+**1. State detection** Scan the conversation for any state signal — teacher mentions a state name, uses state-specific codes (TEKS, SOL, OAS, CA-CCSS, etc.), or says "I teach in [state]." If found, store as state = [state name] and pass it as jurisdiction in the KG standard lookup. Update the default standard framework to match.
+
+**2. Curriculum detection.** Before asking anything, determine whether the teacher is likely using IM (Illustrative Mathematics) curriculum. Look for signals anywhere in the conversation — not just the current prompt: explicit name ("IM", "Illustrative Mathematics", "IM 360"), IM-specific terminology (MLRs, cool-down, "Stronger and Clearer Each Time", IM unit or lesson references), or context that makes IM use probable. If signals are present, treat as **IM-confirmed** and proceed. If absent, treat as **not IM-confirmed**.
+
+When key information is missing, ask. Priority: (1) grade level if missing, (2) topic if missing, (3) curriculum if not inferable, (4) state if not inferable. Infer everything else. Defaults applied silently: 45–60 min, universal access design, CCSS (overridden by the detected state's framework when State Detection finds one).
+
+---
+
+## Standards grounding
+
+Follow **Step 2 — Ground in standards** in SKILL.md: if the Learning Commons Knowledge Graph
+is connected, use the Mathematics section of `references/learning-commons-kg.md`; if not,
+proceed from best knowledge and add the disclaimer footer.
+
+## Build the lesson
+
+**For all lessons**
+Include at least one visual scaffold registered in `shared` (a `data_table`, `number_line`,
+or `fill_table` organizer) and pulled into the lesson plan with the
+teacher-facing rationale beside it. Whether it also appears on the student page depends on
+what it is: a blank `fill_table` students complete or a `number_line` they mark belongs on
+the worksheet; a worked reference table that shows the operation or answer structure is
+teacher-only — printing it gives away the thinking.
+
+Be sure that overall timing and timing for each section is realistic - do not overload the lesson.
+
+### Curriculum branching — apply before drafting
+
+**If IM-confirmed:**
+Use **Launch → Explore → Discuss → Synthesize → Exit Ticket** exactly. Apply IM-specific features:
+- Discourse: *Compare and Connect*, *Stronger and Clearer Each Time*, *Think-Pair-Share*
+- MLRs: use KG recommendations; otherwise default to MLR 2 (Collect and Display) in Explore, MLR 7 (Compare and Connect) in Discuss, MLR 8 (Discussion Supports) where discussion needs support
+- Name 2–3 SMPs verbatim in Section 1; keep tone teacher-friendly, not academic
+
+**If not IM-confirmed:**
+Use **Launch → Explore → Discuss → Synthesize → Exit Ticket** (problem-based). Do NOT use IM-specific terminology: no MLR names, no *Compare and Connect*, no *Stronger and Clearer Each Time*. Use Think-Pair-Share and Turn-and-Talk.
+- **K–2**: CGI — Explore must include at least one start-unknown and one change-unknown problem; for add/subtract story-problem standards the set spans all four situation types (add-to, take-from, put-together/take-apart, compare); exit ticket must target start-unknown or change-unknown; no strategy modeling before student attempt; the visual model students use (tape diagram, number bond, drawing) appears in the materials themselves — on the worksheet or anchor chart — not as an offer
+- **3–5**: Problem-based, gradual release; array/area models in Discuss
+- **6–8**: Problem-based; ratio tables, double number lines, coordinate graphs
+- **9–12**: Mathematical modeling; formalize notation in Synthesize, not Launch
+
+### Problem set — structural variety is required, not optional
+
+Before writing the practice problems (`shared.p1`..`pN`), ENUMERATE the standard's structural cases — the full span
+from the baseline case (the one every student must clear) to the structurally hardest case
+(the one students most often get wrong: start-unknown for K–2 story problems; a product
+smaller than both factors for decimal multiplication; the missing-leg case for the
+Pythagorean theorem; a midpoint or just-below-boundary number for rounding; a
+linear-but-not-proportional relationship for proportionality; and so on for other
+standards). Then write the set so EVERY enumerated case is a numbered, required problem (or
+the exit ticket), with its case named in that problem's `teacher` facet.
+
+Coverage rules:
+- A structural case that appears only in prose — the SWBAT, an anticipated challenge, a
+  teacher move, or the Discuss notes — does NOT count as covered. If the plan's prose names
+  a case, a numbered problem must present it to students.
+- Emphasizing the hardest case never licenses dropping the baseline case: a set of all-hard
+  problems fails coverage exactly as a set of all-easy ones does.
+- The standard's number domain is part of the variety: if the standard or SWBAT says
+  rational numbers, at least one required problem uses fractions or decimals —
+  whole-number-only sets do not cover it.
+- Never relegate a required structural case to an optional extension or bonus — if it only
+  appears as a challenge add-on, most students never meet it.
+- State once which problem carries each case (exit ticket included) — a coverage gap
+  should be visible at a glance, to you and to the teacher.
+
+### Section structure — both paths
+
+1. **At a glance** — standard verbatim in a `special` callout (the ONE verbatim quote — everywhere else standards go by code + a short gist); a one-line lesson arc naming the phases with minutes ("Launch 8 → Explore 15 → Discuss 12 → Synthesize 5 → Exit 5") so the period's shape is visible before any detail; materials — name each item plainly (e.g. "Number cards 0-20"); SMPs named
+2. **Learning goal** — Big Idea (enduring understanding, 1 sentence); SWBAT; Prerequisite (prior standard by code + one plain sentence on what students can already do and how today builds on it)
+3. **Vocabulary & anticipated challenges** — 3–5 key terms with brief definitions; 2–3 misconceptions each as: *What students do* / *Why it happens* / *Teacher move*
+4. **Lesson sequence** — phases per curriculum branch above; **Discuss gets at least 10 minutes** (in a short warm-up-style request, shrink the other phases, not Discuss); in Explore: 3+ look-fors each naming the student response, why it matters, and what to do with it — and if the anchor task admits more than one correct response or equation, one look-for must say so explicitly so the teacher accepts all of them; in Discuss: at least one named student-to-student talk move (Think-Pair-Share, Turn-and-Talk, partner compare, agree/disagree) + specific discourse prompts (not generic)
+5. **Design notes** — last section, after the exit ticket: 2–3 elements to keep intact when
+   adapting, with brief reasoning, including the lesson's central representation (the visual
+   or model students work with) and its one-sentence why. Rationale lives here, after the
+   teaching path — a teacher prepping reads the arc first, the reasoning second.
+
+## Exit ticket guidance
+
+The exit ticket is the last phase in Lesson Sequence (`from_shared:exit_ticket` under its phase header).
+
+- It IS the **structurally hardest enumerated case** (from the problem-set enumeration above; K–2: start-unknown or change-unknown), never a mid-difficulty stand-in. Pick it with the **misconception test**: a student who holds the lesson's primary anticipated misconception must get the exit ticket WRONG. If that student would get it right, you picked an affirming instance — swap it for the discriminating one (a lesson distinguishing X from not-X exits on the not-X case; a lesson fixing a placement habit exits where that habit produces a wrong answer). Name the case in `shared.exit_ticket.teacher`.
+
+- **Verify the exit ticket and every answer key by working the problem**: the stated answer is the one the problem actually produces, and the operation count matches the standard (a one-step-equation lesson exits on a one-step equation).
+
+- 3 sort buckets — *Got it* / *Almost there* / *Needs re-teaching* — **each with explicit criteria** describing what a response in that bucket contains (e.g. "Got it: correct equation with the unknown where it lives in the story", not the bare label); all three criteria appear in the lesson plan, never truncated to labels.
+
+---
+
+## Writing lesson.json — math mapping
+
+When you reach Step 5 (Output) in SKILL.md, register math content in `shared` and compose
+`documents[]` like this:
+
+- `shared.subject`: `"Mathematics"`; `shared.smps`: the 2–3 SMPs, named verbatim.
+- `shared.anchor_task`: `{teacher: <launch script + facilitation note>, student: <the task as
+  the student reads it, second person>}`.
+- Each practice problem as its own key — `shared.p1`..`pN`: `{student: <prompt text>}`,
+  optionally `{teacher: <what to watch for on this item>}` and `stimulus: [blocks]` (a
+  `data_table` the problems share, a `number_line`, etc.). A shared data set used by several
+  problems can be its own key (e.g. `shared.prices_table`) and pulled once before the set.
+- Register the visual scaffold as its own `shared` key (e.g. `shared.hundreds_chart`,
+  `shared.prices_table`, `shared.tape_diagram`) — a `data_table`, `number_line`, or
+  `fill_table` block — and pull it into the lesson plan next to the rationale. Pull it onto
+  the student page only when it is something students work with (a blank organizer, a number
+  line to mark, the data set the problems analyze); a worked reference table the teacher
+  uses to structure the mini-lesson stays teacher-side.
+- `shared.exit_ticket`: `{student: <prompt — a fresh item, never a duplicate of a practice
+  problem>, teacher: <collection note>}`. The sort criteria are a `cards` block you place in
+  the lesson plan after pulling the exit ticket (see `example_lesson.json`).
+- `shared.vocabulary`, `shared.misconceptions`, `shared.look_fors`: register each as the
+  block you want rendered (a `table` for misconceptions, a `list` for look-fors) — there is
+  no special-case rendering by key name.
+
+**Student page layout** (the `id: "student_materials"` document) — start from this skeleton
+and adapt:
+
+```
+sections:
+  "<warm-up heading, kid-facing>"  group[ from_shared:anchor_task, answer_box ]
+  "<practice heading>"     optional callout(student-note) — a brief reminder, only when one helps
+                           from_shared:<visual-scaffold key>   ← only when it is something
+                             students work with (blank fill_table, number_line, the data
+                             set the problems analyze) — a worked reference table is
+                             teacher-only
+                           for each problem k:
+                             group[ {type: from_shared, key: pk, label: "k"},
+                                    answer_box (bare -- it sizes to the grade band;
+                                    ruled: true when the answer is composed sentences) ]
+                           on the ONE problem whose hard part is the writing move, its
+                             group also carries the sentence support -- plain text before
+                             the answer_box (see Sentence supports in SKILL.md)
+                           page_break
+  "<exit heading, kid-facing>"     group[ from_shared:exit_ticket, answer_box ]
+```
+
+**Observation template layout** (the `id: "observation_template"` document):
+
+```
+sections:
+  "How to use this"        one-paragraph instructions
+  "Look-fors"              from_shared:look_fors
+                           fill_table headers=[Student, Strategy seen, Next step] blank_rows=8
+  "Anticipated challenges" from_shared:misconceptions
+  "Exit-ticket sort"       from_shared:exit_ticket
+```
+
+Worked example: `references/example_lesson.json`.

--- a/skill-library/k12-lesson-planning/references/science.md
+++ b/skill-library/k12-lesson-planning/references/science.md
@@ -1,0 +1,182 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Science — lesson pedagogy
+
+Loaded by `k12-lesson-planning` when the subject is **science**.
+
+## Clarify
+
+Before asking anything, assess the following from all available conversation signals:
+
+**1. State detection:** Scan the conversation for any state signal — teacher mentions a state name, uses state-specific codes (TEKS, SOL, OAS, CA-NGSS, etc.), or says "I teach in [state]." If found, store as state = [state name] and pass it as jurisdiction in the KG standard lookup. Update the default standard framework to match.
+
+**2. Curriculum detection.** Look for signals that the teacher is using OpenSciEd anywhere in the conversation — not just the current prompt: explicit name ("OpenSciEd", "OSE"), OSE-specific terminology (anchoring phenomenon, driving question, consensus model, "figuring out"), or context that makes OSE use probable. If signals are present, treat as **OSE-confirmed** and proceed. If absent, treat as **not OSE-confirmed**.
+
+**3. Grade band.** Determine from grade level which band applies:
+- **K–2**: concrete phenomena, teacher-facilitated sensemaking, oral and drawn models
+- **3–5**: transitional — written Claim-Evidence-Reasoning (CER) begins, mechanistic models, simple data analysis
+- **6–8**: integrated across disciplines, quantitative reasoning, formal argumentation
+- **9–12**: mathematical modeling, extended investigations, societal/ethical dimensions
+
+**4. Standard and phenomenon context.** Note whether the teacher has specified a state or NGSS Performance Expectation code (e.g., `MS-LS2-3`) or a topic. Note whether they've specified an anchoring phenomenon or unit context. If not, draw from the KG calls (see learning-commons-kg.md). Flag any selections in Section 1 as suggested.
+
+When key information is missing, ask. Priority: (1) grade level if missing, (2) topic or standard if missing, (3) unit position if helpful context (4) state if not inferable. Infer everything else. Defaults applied silently: NGSS, 45–60 min, universal access design.
+
+---
+
+## Standards grounding
+
+Follow **Step 2 — Ground in standards** in SKILL.md: if the Learning Commons Knowledge Graph
+is connected, use the Science section of `references/learning-commons-kg.md`; if not,
+proceed from best knowledge and add the disclaimer footer.
+
+## Build the lesson
+
+**For all lessons** 
+include at least one visual scaffold with a teacher-facing rationale justifying the choice. 
+
+Also be sure that overall timing and timing for each section is realistic - do not overload the lesson.
+
+### Curriculum branching — apply before drafting
+
+**If OSE-confirmed (OpenSciEd):**
+The teacher already has the OpenSciEd curriculum. Write a **distinct lesson** that complements rather than duplicates what they already have — do not replicate or lightly adapt any OSE lesson. Use the KG OSE materials (learning-commons-kg.md, Science call 2) to understand what phenomenon, practices, and routines OSE uses for this standard, then design an original investigation and discussion sequence that covers the same three-dimensional learning differently.
+
+Use OSE format and language throughout, on top of the grade-band structure below:
+- Learning targets stated as "Students will figure out…" or "Students will use [SEP] to [DCI/CCC]"
+- Driving question posted and returned to at lesson close
+- Consensus model revision as the primary explanation-building move
+- Class tracking board or "what we know / what we're still figuring out" updated each lesson
+- CER (Claim–Evidence–Reasoning) as the formative writing structure
+
+**If not OSE-confirmed:**
+Use the KG OSE materials (learning-commons-kg.md, Science call 2) as an HQIM design exemplar — draw on phenomenon selection, practice foci, and task logic to calibrate quality, then write original content. Do NOT use OSE-specific terminology: no "consensus model", no driving question framing, no OSE unit or lesson references in the plan.
+
+---
+
+### Grade band — apply before drafting
+
+Grade band is the primary structural branch. Determine from grade level and apply the matching structure.
+
+---
+
+#### K–2: Concrete Phenomena, Teacher-Facilitated Sensemaking
+
+Phases: Launch Phenomenon → Investigation → Sensemaking Discussion → Model/Representation → Exit Ticket
+
+- **Launch Phenomenon — 5–10 min**: Show or do the phenomenon directly — something students can observe, touch, or watch. Do NOT explain it. Ask: "What do you notice? What do you wonder?" Record student observations and questions. Post the lesson's driving question in simple language.
+- **Investigation — 15–20 min**: Hands-on exploration. Students observe, sort, measure, or build. Activity generates concrete data or observations relevant to the phenomenon. Instructions are brief, visual, and modeled. Students record through drawing + simple labels — not fill-in-the-blank worksheets.
+- **Sensemaking Discussion — 10 min**: Teacher facilitates whole-class discussion using students' observations as raw material. Ask students to share what they noticed and connect it to the driving question. Teacher does NOT reveal the explanation — students construct it. Record emerging ideas on board.
+- **Model/Representation — 5–10 min**: Students draw a model to explain what they think is happening. For OSE-confirmed: students update a class consensus model displayed on the wall. Focus on: what you can see AND what you can't see but infer.
+- **Exit Ticket — 3–5 min**: One drawing or oral prompt: "Draw what you think is happening and tell me why."
+
+**Non-negotiables for K–2:**
+- Phenomena must be directly observable — no abstract explanations, no videos of distant phenomena as the primary hook.
+- Investigation before explanation — students collect data first; teacher does not explain the phenomenon before they investigate.
+- Models are the primary representation — drawings that show mechanism, not just illustration.
+
+---
+
+#### Grades 3–5: Written Claim-Evidence-Reasoning Begins, Mechanistic Models
+
+Phases: Launch Phenomenon → Investigation → Sensemaking Discussion → Claim-Evidence-Reasoning Writing → Model Update → Exit Ticket
+
+- **Launch Phenomenon — 5–10 min**: Present a specific, puzzling observable event. Do NOT reveal the explanation. Ask: "What do you notice? What do you wonder? What questions do we need to answer to explain this?" Post the driving question. Connect explicitly to prior lessons: "Last time we figured out ___. Does that help us here?"
+- **Investigation — 15–20 min**: Students carry out an investigation (lab, data analysis, or scientific text analysis) to gather evidence. Assign a clear SEP role: are they planning an investigation, analyzing data, or constructing an explanation from a text? Students record data in a structured format. Look-fors: 3+ named, with specific student behaviors and teacher moves.
+- **Sensemaking Discussion — 10–15 min**: Think-Write-Pair-Share → whole class. Teacher sequences student responses from simple observations toward mechanistic explanations. Push explicitly toward the CCC: "What pattern do you notice in your data? What does that tell us about cause and effect here?"
+- **Claim-Evidence-Reasoning Writing — 10 min**: Students write a structured response. Claim–Evidence–Reasoning format required.
+- **Model Update — 5 min**: Students add to or revise their model to incorporate today's new understanding. What changed? What does the model now show that it didn't before?
+- **Exit Ticket — 3–5 min**: A new small phenomenon (not the one investigated). Students apply today's CCC/DCI: "Use what you figured out today to explain why ___." Sort: *Got it* / *Almost there* / *Needs re-teaching*.
+
+**Non-negotiables for 3–5:**
+- CER every lesson that involves investigation. If a student's response doesn't include evidence from the investigation and reasoning that connects it to a science idea, it is not complete.
+- Models must be mechanistic — show how and why, not just label what. A labeled diagram that could have been drawn before the lesson is not a model revision.
+- Crosscutting concepts must be named explicitly by students, not just implied. Teachers should post the relevant CCC and require students to use it in discussion and writing.
+
+---
+
+#### Grades 6–8: Integrated, Quantitative, Formal Argumentation
+
+Phases: Launch Phenomenon → Investigation → Argumentation Discussion → Claim-Evidence-Reasoning Explanation → Model Revision → Formative Check
+
+- **Launch Phenomenon — 5–10 min**: Present a specific, complex observable event. Students write a brief initial explanation before investigating (they will return to this). Post the unit driving question. Connect to the unit storyline: "We've been trying to explain ___. Last lesson we figured out ___. Here's something new that our model needs to be able to explain."
+- **Investigation — 20–25 min**: Students carry out a quantitative investigation or data analysis. Assign the SEP explicitly. Mathematical reasoning is central — graphs, rates, proportions, computational models as appropriate. Students should be analyzing, interpreting, and making sense of data — not just recording it. Look-fors: 3+ named, with specific behaviors and teacher moves for both the SEP in use and the foregrounded CCC.
+- **Argumentation Discussion — 15 min**: Students defend claims with data. Teacher facilitates evidence-based argumentation — not just sharing answers. Require students to cite specific data points, not just patterns. Push toward the CCC explicitly: "What does your data tell us about [energy and matter / systems / cause and effect]?" For OSE-confirmed: update class consensus model or tracking board as part of discussion.
+- **Claim-Evidence-Reasoning Explanation — 10 min**: Written evidence-based explanation. Grades 6–7: Claim-Evidence-Reasoning format. Grade 8: introduce competing explanations — students must address and rebut an alternative explanation.
+- **Model Revision — 5–10 min**: Revise the explanatory model (individual and/or class consensus) to reflect new understanding. What does the model now explain that it couldn't before? What does it still not explain?
+- **Formative Check — 5 min**: Students compare their opening quick-write to their revised explanation: "What changed in your thinking? What specific evidence caused that change?"
+
+**Non-negotiables for 6–8:**
+- Quantitative reasoning is not optional. If the data is quantitative, students must use numbers — not just qualitative descriptions — in their claims and CERs.
+- Argumentation requires evidence from the investigation, not from prior knowledge. "I already knew that" is not scientific evidence.
+- Model revision is cumulative. By the end of the unit, the class consensus model should visibly show the progression of understanding across lessons.
+
+---
+
+#### Grades 9–12: Mathematical Modeling, Societal Dimensions, Sustained Investigation
+
+Phases: Launch Phenomenon → Investigation → Scientific Argumentation → Explanation/Modeling → Science-Society Connection → Formative Check
+
+- **Launch Phenomenon — 5–10 min**: A complex, socially or scientifically relevant observable phenomenon. Students write an initial mechanistic explanation independently — silence is productive. Post the unit driving question. Connect to the unit's developing explanatory model: what piece of the big puzzle does this lesson investigate?
+- **Investigation — 20–25 min**: Extended, student-directed investigation. Students may be designing their own procedures, analyzing real-world data sets, using computational simulations, or evaluating competing models. Mathematical modeling is central where relevant — equations, graphs, computational tools as explanatory tools. Look-fors: 3+ named for both the primary SEP and the CCC.
+- **Scientific Argumentation — 15 min**: Student-to-student discourse. Teacher probes; does not direct. Students cite specific data and quantitative evidence. Surface competing explanations or models and evaluate them. Require: "What evidence would make you change your mind?" Always debrief argumentation quality, not just content: "Did we distinguish between a claim and evidence? Whose idea changed because of someone else's evidence?"
+- **Explanation/Modeling — 15 min**: Sustained written explanation or formal model construction. Uses SEPs at full sophistication: develop a mathematical model, construct a scientific explanation citing quantitative evidence, design a solution with engineering justification. Counterclaim or alternative-model acknowledgment required.
+- **Science-Society Connection — 5 min**: Explicit discussion of implications: how does this scientific understanding connect to a real-world decision, policy, or ethical question? This is not optional enrichment — it is part of the NGSS vision for high school science.
+- **Formative Check**: Students return to opening quick-write. Self-assess: "What in your original explanation was correct? What was incomplete or wrong? What specific evidence revised your thinking?"
+
+**Non-negotiables for 9–12:**
+- Mathematical models are explanatory, not decorative. An equation or graph that a student cannot connect to a physical mechanism is not modeling — it is calculation. Students must explain what each variable represents and why the relationship takes the form it does.
+- Scientific uncertainty is explicit. High-quality HS science acknowledges where models break down, where data is limited, and what remains genuinely unknown. Treating scientific knowledge as settled facts undercuts the epistemic goal of the standards.
+- Science–society connections are substantive, not tacked on. Require students to reason from the science to the social/ethical implication — not just name a "real-world connection."
+
+---
+
+### Section structure — all grade bands
+
+1. **At a glance** — standard verbatim in a `special` callout; a one-line lesson arc naming the phases with minutes so the period's shape is visible before any detail; anchoring phenomenon (title / brief description, or [suggested] flag); materials list — name each item plainly (e.g. "Data-recording cards")
+2. **Three-dimensional learning targets** — state each dimension explicitly and separately, with framework names spelled out: Science and Engineering Practice ("Students will [practice verb] to [purpose]"); Disciplinary Core Idea ("Students will understand that [specific content idea]"); Crosscutting Concept ("Students will apply [named concept] to [specific use]"). Do not merge dimensions into a single vague objective.
+3. **Unit storyline context** — 2–3 sentences. When the teacher has said where this lesson sits in a unit, place it: what students figured out last time, how today advances the explanation. When they haven't, write the lesson to stand alone and connect it by concept, not by position — name the ideas it builds on and the ones it pairs with ("builds on what students know about living things; pairs naturally with cells whenever you teach them"). Schools sequence topics their own way; a placement guess from the standards' canonical order is only right for schools that follow it.
+4. **Vocabulary** — a reference list of the terms this lesson introduces, with
+   student-friendly definitions. A term is here because a phase teaches it (anchored to
+   something concrete — the diagram, an analogy, what students just observed); a term on a
+   student page that no phase teaches is a gap in the lesson, not in this list.
+5. **Anticipated student ideas & misconceptions** — up to 3 entries from the KG OSE-materials call or training knowledge, each formatted: *What students think* / *Why it persists* / *Teacher move*
+6. **Lesson sequence** — phases per grade band above; in every investigation phase: 3+ look-fors each naming the specific student behavior, why it matters for the 3D standard, and what to do; in every discussion phase: specific science-based prompts (not generic)
+7. **Design notes** — last section, after the exit ticket: 2–3 elements to keep intact when adapting, each with a brief reason grounded in three-dimensional learning, including the lesson's central representation (model, diagram, or data display) and its one-sentence why.
+
+→ **Section structure complete. Proceed to the draft (when the teacher chose one) or Step 5.**
+
+## Exit ticket guidance
+
+The exit ticket is the last phase in Lesson Sequence (`from_shared:exit_ticket` under its phase header). One item that requires students to apply today's DCI using a SEP and the lesson's CCC. K-2: a drawing or oral prompt. 3-5: a new small phenomenon (not the one investigated) that students explain using what they figured out today. 6-12: return to the opening quick-write and self-assess what evidence changed your thinking. Three sort buckets (Got it / Almost there / Needs re-teaching).
+
+---
+
+
+## Writing lesson.json — science mapping
+
+When you reach Step 5 (Output) in SKILL.md, map science content to the material-source JSON like this:
+
+- `shared.subject`: `"Science"`
+- `shared.standard_code` / `shared.standard_text`: the Performance Expectation, verbatim
+- `shared.anchor_task`: the anchoring phenomenon —
+  `{teacher: <how to present it without explaining it>, student: <what students observe/do>}`.
+- Each investigation or explanation task as `shared.t1`..`tN`:
+  `{teacher: <facilitation script>, student: <the task as students read it>, stimulus?: [data
+  table or diagram blocks both pages show]}`.
+- `shared.exit_ticket`: `{student: <prompt>, teacher?: <collection note>}`. The sort
+  criteria are a `cards` block you place in the lesson plan after pulling the exit
+  ticket (see `example_lesson.json`).
+- Three-dimensional learning targets: three separated bullets, one per dimension, each
+  labeled with the spelled-out name (Science and Engineering Practice / Disciplinary Core
+  Idea / Crosscutting Concept).
+- In the observation template, prefix each look-for with its dimension so the teacher sees
+  which one they're watching for.
+- `shared.vocabulary`, `shared.misconceptions`, `shared.look_fors` as in the SKILL.md schema.
+- Student-page section headings in plain inquiry language ("What do you notice?",
+  "Investigation") — you compose them directly in the document's sections.
+

--- a/skill-library/k12-lesson-planning/references/social_studies.md
+++ b/skill-library/k12-lesson-planning/references/social_studies.md
@@ -1,0 +1,200 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anthropic, PBC
+SPDX-FileCopyrightText: 2026 Learning Commons
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Social Studies — lesson pedagogy
+
+Loaded by `k12-lesson-planning` when the subject is **social studies / history**. This subject
+follows the C3 inquiry arc, generates a **single lesson** positioned within a unit arc, and
+**points to** primary sources rather than reproducing them.
+
+Lessons follow the C3 Framework inquiry arc:
+- Developing compelling and supporting questions — sparks curiosity and drives a unit
+- Applying disciplinary concepts and tools — from civics, economics, geography, and history
+- Evaluating sources and using evidence — disciplinary literacy and critical thinking
+- Communicating conclusions and taking informed action — civic application
+
+**C3 Framework note.** The C3 Framework is an *inquiry design* framework, not a standards document. Use C3 for instructional design (the inquiry arc, sourcing, argumentation, civic action), but the lesson's content scope and the verbatim standard must come from the **state** standard — never substitute a C3 dimension or indicator for the standard, and never fall back to C3 when a state standard is unavailable.
+
+## Gather inputs
+
+If the user has not already provided the following, ask for them before generating:
+
+- **Grade band**: K–2, 3–5, 6–8, or 9–12
+- **Topic or era**: e.g., "Reconstruction," "the civil rights movement," "ancient Rome," "World War I"
+- **Compelling question** (optional — you will draft one if not provided): a contestable, civically resonant question that could anchor a multi-day unit
+- **Specific standard or focus skill** (optional): e.g., "causation," "sourcing," "continuity and change over time"
+- **State** (required): Social studies standards are state-specific. If the teacher does not name a state and it is not inferrable, ask.
+
+Do not ask about Taking Informed Action, multi-discipline integration, or curriculum context — those are out of scope for this skill.
+
+
+## Standards grounding
+
+Follow **Step 2 — Ground in standards** in SKILL.md: if the Learning Commons Knowledge Graph
+is connected, use the Social Studies section of `references/learning-commons-kg.md`; if not,
+proceed from best knowledge and add the disclaimer footer.
+
+## Draft a compelling question (if not provided)
+
+The compelling question must be:
+- Genuinely contestable (not a yes/no or factual lookup)
+- Civically or humanly resonant — students should feel it matters
+- Answerable through historical evidence
+- Appropriate in complexity for the grade band
+
+Examples by grade band:
+- K–2: "Why do people move to new places?" / "How do communities change over time?"
+- 3–5: "Was Westward Expansion good for America?" / "What made the American Revolution possible?"
+- 6–8: "Was World War I inevitable?" / "How did ordinary people shape the civil rights movement?"
+- 9–12: "When is civil disobedience justified?" / "Did Reconstruction succeed or fail — and for whom?"
+
+
+## Build the lesson plan
+
+Build the lesson plan with the following sections — these become the `sections` array of the
+`lesson.json` (the material source) in Step 5 — Output (one JSON section per `##` heading below; the template's
+formatting hints map to renderer block types: blockquotes → `callout` blocks, bold labels →
+`labeled` blocks, lists → `bullets`). Adjust vocabulary, task complexity, and source type by
+grade band (see guidance below).
+
+**For all lessons**
+Include at least one visual scaffold that appears concretely on the student page — the
+`source_card` excerpts themselves, a `fill_table` evidence organizer, or a timeline —
+registered in `shared` and pulled via
+`from_shared` so the same scaffold appears in the lesson plan with the teacher-facing
+rationale beside it.
+
+Be sure that overall timing and timing for each section is realistic - do not overload the lesson.
+
+---
+
+### Section structure — teaching order
+
+1. **At a glance** — grade band; time; standard verbatim in a `special` callout (the ONE
+   verbatim quote — everywhere else standards go by code + short gist); a one-line lesson arc
+   naming the phases with their minutes (e.g. "Hook 5 -> source work 20 -> discussion 15 ->
+   exit 10") so the shape of the lesson is visible before any detail; the lesson's C3 inquiry
+   focus in plain words (e.g. "C3: evaluating sources and using evidence"); materials —
+   name each item plainly.
+2. **Compelling & supporting questions** — the unit-level question, and the narrower question
+   this single lesson investigates (one of the 3–5 that would make up the full unit).
+3. **Lesson goals & background for the teacher** — 1–2 SWBATs; assumed prior knowledge,
+   specific; 2–3 anticipated challenges for this topic and source set (*what students do* /
+   *why it happens* / *teacher move*); Key
+   vocabulary (4–6 terms, defined at grade level, each introduced at the moment the
+   lesson needs it). The background content itself lives inside the lesson sequence, in the
+   phase that delivers it.
+4. **Source set (2 sources)** — sources are real, high-quality, and specifically cited
+   (title, author, date, archive). If you have web search, confirm before using. A
+   public-domain text source (pre-1929, government documents) gets an excerpt reproduced, sized to the analysis the questions ask of it
+   as a `source_card`; an image, photograph, political cartoon, or copyrighted text isn't
+   reproduced — name it (title, citation, where to find it) in Materials and the phase that
+   uses it. Register each reproduced source in `shared` under its own key. For each source:
+   the card itself (its citation carries where the text lives — full URL when you verified it
+   resolves this session; otherwise the archive and collection by name, nothing more — the
+   same rule covers call numbers and catalog IDs, which appear only verified) plus
+   ONE sentence of why this source, as a labeled line. Procurement details, search tips, and
+   alternate locations don't help a teacher mid-prep — leave them out. Close the section with
+   one sentence on the pairing — the tension or contrast the two sources create.
+5. **Lesson sequence** — phases in teaching order, minutes summing exactly to the period:
+   background knowledge (this phase carries its content inline — the short labeled chunks
+   the teacher actually says, a half page at most, never an essay) → source work with
+   **2–3 guided analysis questions** (scaffolded:
+   observe → source or contextualize → corroborate and connect to the supporting question) →
+   discussion → exit ticket.
+6. **Exit ticket** — students answer the supporting question with evidence from the sources.
+   Sized to the minutes remaining in the period: a claim plus one or two pieces of cited
+   evidence, per the grade band below — never a take-home essay. 2–3 success-criteria bullets.
+7. **Design notes** — 2–3 elements to keep intact when adapting, each with a one-sentence
+   reason grounded in the standard, including the lesson's central organizer or source-work
+   structure and its one-sentence why.
+
+## Grade-Band Guidance
+
+Apply these adjustments throughout the lesson:
+
+**K–2**
+- Background knowledge delivered as read-aloud or class discussion, not independent reading
+- Sources: photographs, illustrations, artifacts, oral histories — avoid dense text
+- Analysis questions are discussed orally before writing
+- Exit ticket: drawing + 1–2 dictated or written sentences; or a class discussion with teacher-recorded responses
+- Vocabulary: 4 words max, defined with visuals or gestures
+
+**3–5**
+- Background knowledge can be a short informational text (Lexile 600–850) or teacher-led mini-lecture
+- Sources: accessible primary sources with some scaffolding (sentence-level glosses on hard vocabulary); photographs and short documents work well
+- Analysis questions answered in writing
+- Exit ticket: 1 paragraph using the claim-evidence-reasoning structure
+- Vocabulary: 5–6 words; students interact with words before source reading
+
+**6–8**
+- Background knowledge as assigned reading or lecture notes; students should be able to read and annotate independently
+- Sources: more complex primary sources (letters, speeches, political cartoons, data); students expected to do basic sourcing independently
+- Analysis questions answered in writing
+- Exit ticket: short constructed response (1–2 paragraphs), evidence-based; may include a claim + two pieces of evidence
+- Vocabulary: disciplinary terms emphasized (e.g., "corroborate," "perspective," "contextualize")
+
+**9–12**
+- Background knowledge delivered via complex texts; students expected to take notes and synthesize
+- Sources: challenging primary and secondary sources; students source, contextualize, and corroborate independently
+- Analysis questions push toward argument construction and acknowledgment of counterevidence
+- Exit ticket: a claim with cited evidence and reasoning, acknowledging complexity — sized to the minutes remaining
+- Vocabulary: discipline-specific and college-level terms assumed or quickly reviewed
+
+## Writing lesson.json — social studies mapping
+
+When you reach Step 5 (Output) in SKILL.md, register social-studies content in `shared` and
+compose `documents[]` like this:
+
+- `shared.subject`: `"Social Studies"`.
+- `shared.supporting_question`: the supporting question (one sentence, student-facing).
+- Each source as its own key — `shared.source_a`, `shared.source_b`: a `source_card` block
+  (title, author, date, origin, **excerpt** — reproduce a public-domain excerpt sized to the analysis when
+  the source is pre-1929 or government text). A source you cannot reproduce (an image,
+  political cartoon, photograph, copyrighted text) is named in the lesson plan — title,
+  citation, where to find it — not represented on the student page.
+  When you write an excerpt that paraphrases or composites period
+  language rather than quoting a specific document verbatim, set `origin` to
+  `"adapted from <publication>, <year>"` so the card is honest about provenance — and cite
+  the collection, not a page number: page-precise citations ("p. 254") belong only on text
+  quoted verbatim from that page, and every quotation is attributed to the document it
+  actually comes from. Register
+  each *Why this source* line under a teacher-only key (`shared.source_a_rationale`, etc.)
+  so it never renders on the student page — one sentence; the citation already says where
+  the text lives.
+- Each guided analysis question as `shared.q1`..`q3` (2–3 questions): `{student: <question>}`. Every question names its target — "Source A", "Source B", or "both sources" — a student with two sources in hand can't act on "this source".
+- `shared.exit_ticket`: `{student: <exit-ticket prompt>, teacher?: <collection note>}`.
+  The three sort entries (standard labels, explicit criteria) are a `cards` block you place
+  in the lesson plan after pulling the exit ticket (see `example_lesson.json`).
+- `shared.vocabulary`, `shared.misconceptions`, `shared.look_fors` as in the SKILL.md schema.
+
+**Documents to emit.** Social-studies inquiry lessons always have written analysis
+questions, so **always include `id: "student_materials"`** alongside `lesson_plan` and
+`observation_template`. When sources are registered, also include `id: "source_packet"`
+(one `from_shared` per source, plus a one-line "Read these with the worksheet" note). The
+student worksheet opens with "*See your Source Packet for Source A and Source B.*"
+
+**Student page layout** (the `id: "student_materials"` document):
+
+```
+sections:
+  "Supporting question"    callout(student-task) from_shared:supporting_question
+  "Sources"                from_shared:source_a ; from_shared:source_b
+  "Analyze the sources"    for each question k:
+                             group[ {type: from_shared, key: qk, label: "k"},
+                                    answer_box ]
+                           page_break
+  "Make your claim"        group[ from_shared:exit_ticket, answer_box ~180pt ]
+```
+
+The Background-Knowledge Builder, source-pairing rationale, and *Why chosen / Where to find
+it* live only in the `lesson_plan` document — pull them with their teacher-only keys there.
+
+**Observation template layout**: as in `references/math.md`, with `fill_table` headers
+`[Student, Evidence of thinking, Instructional move]`.
+
+Alongside the documents, briefly note which source collection(s) likely have the recommended
+sources, and any coherence flag about assumed prior knowledge.

--- a/skill-library/k12-lesson-planning/scripts/lesson_common.py
+++ b/skill-library/k12-lesson-planning/scripts/lesson_common.py
@@ -1,0 +1,763 @@
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared-content helpers used by all artifact renderers.
+
+The material-source JSON has a `shared` block holding every piece of content that appears in more
+than one artifact (standard, anchor task, problems, exit ticket, look-fors, vocabulary,
+misconceptions, sentence supports). Renderers expand it via `expand_from_shared`, so shared
+content is written once and can never drift between artifacts.
+"""
+from __future__ import annotations
+
+import re
+
+# ---- render-time print-safety repair ---------------------------------------------------
+# Two failure classes survive prompt instructions and are repaired structurally instead:
+# (1) markdown pipe tables drawn inside prose fields print as literal '|' rows — convert
+#     them to real `table` blocks; (2) the ■ unknown-number symbol appearing in an artifact
+#     with no defining sentence in THAT artifact (look-fors carry ■ into the observation
+#     sheet via from_shared, where the model writes no prose) — append the skill's standard
+#     definition line to the first section that uses it.
+
+_PIPE_LINE = re.compile(r"[^|\n]*\|[^|\n]+\|")            # a line with >=2 pipe chars
+_SEP_LINE = re.compile(r"^\s*\|?[\s:|\-]+\|?\s*$")        # |---|:---| separator row
+UNKNOWN_SYMBOL = "■"
+_UNKNOWN_DEFINED = re.compile(
+    r"(use|using|write|stands for|symbol|means)[^.]{0,50}■"
+    r"|■[^.]{0,50}(for the|stands for|means|is the|if you need)", re.IGNORECASE)
+
+
+def _parse_pipe_rows(lines: list[str]) -> list[list[str]]:
+    rows = []
+    for ln in lines:
+        if _SEP_LINE.match(ln):
+            continue
+        rows.append([c.strip() for c in ln.strip().strip("|").split("|")])
+    width = max((len(r) for r in rows), default=0)
+    return [r + [""] * (width - len(r)) for r in rows]
+
+
+_INLINE_SEP = re.compile(r"\|\s*:?-{2,}")  # an inline |--- separator (table collapsed to one line)
+_BULLET_LINE = re.compile(r"^\s*(?:[•▪‣◦]|[-–])\s+")
+
+# Enumerated sub-parts written mid-prose — "… from Task 1: (a) Predict … (b) Describe …" —
+# read as a wall of text. Insert a line break before each "(a)"/"(1)" marker that follows
+# sentence-ending punctuation, so every sub-part starts on its own line. Both renderers
+# preserve single newlines as line breaks.
+_ENUM_MIDPROSE = re.compile(r"(?<=[.!?:;])[ \t]+(?=\((?:[a-h]|\d{1,2})\)\s)")
+
+# Standards bodies write sub-parts as "A. Describe ... B. Describe ..." mid-prose; a verbatim
+# standard then renders as a wall of text. Break before each capital-letter marker -- but only
+# when the text carries a real enumeration (both "A." and "B." present after sentence ends),
+# so initials like "Emmett J. Scott" never trigger it.
+_CAP_MARKER = re.compile(r"(?<=[.?])[ \t]+(?=([A-H])\.\s+[A-Z])")
+
+
+def _repair_cap_subparts(text: str) -> str:
+    letters = {m.group(1) for m in _CAP_MARKER.finditer(text)}
+    if not {"A", "B"} <= letters:
+        return text
+    return _CAP_MARKER.sub("\n", text)
+
+
+
+def _repair_enum_breaks(blk: dict) -> list[dict]:
+    """Put mid-prose enumerated sub-parts ('(a) …', '(2) …') on their own lines."""
+    if blk.get("type") == "group":
+        return [dict(blk, blocks=[rb for b in blk.get("blocks", [])
+                                  for rb in _repair_enum_breaks(b)])]
+    if blk.get("type") == "columns":
+        return [dict(blk,
+                     left=[rb for b in blk.get("left", []) for rb in _repair_enum_breaks(b)],
+                     right=[rb for b in blk.get("right", []) for rb in _repair_enum_breaks(b)])]
+    if blk.get("type") in ("paragraph", "labeled", "callout") and isinstance(blk.get("text"), str):
+        fixed = _repair_cap_subparts(_ENUM_MIDPROSE.sub("\n", blk["text"]))
+        if fixed != blk["text"]:
+            return [dict(blk, text=fixed)]
+    return [blk]
+
+
+def _repair_inline_bullets(blk: dict) -> list[dict]:
+    """Split prose containing bullet-marked lines ('• item') into prose + bullets blocks.
+    A paragraph renders newlines as spaces, so bullets written inside a text string run
+    together into one unreadable line."""
+    if blk.get("type") == "group":
+        return [dict(blk, blocks=[rb for b in blk.get("blocks", [])
+                                  for rb in _repair_inline_bullets(b)])]
+    if blk.get("type") == "columns":
+        return [dict(blk,
+                     left=[rb for b in blk.get("left", []) for rb in _repair_inline_bullets(b)],
+                     right=[rb for b in blk.get("right", []) for rb in _repair_inline_bullets(b)])]
+    if blk.get("type") not in ("paragraph", "labeled") or not isinstance(blk.get("text"), str) \
+            or "\n" not in blk["text"]:
+        return [blk]
+    lines = blk["text"].split("\n")
+    if not any(_BULLET_LINE.match(ln) for ln in lines):
+        return [blk]
+    out: list[dict] = []
+    buf: list[str] = []
+    items: list[str] = []
+    first = True
+
+    def flush_text():
+        nonlocal first
+        t = "\n".join(buf).strip()
+        if t:
+            out.append(dict(blk, text=t) if first else {"type": "paragraph", "text": t})
+            first = False
+        buf.clear()
+
+    def flush_items():
+        nonlocal first
+        if items:
+            if first and blk.get("type") == "labeled" and blk.get("label"):
+                # The block opens with bullets — keep its label as a lead-in line
+                # instead of silently dropping it.
+                out.append({"type": "labeled", "label": blk["label"], "text": ""})
+            out.append({"type": "list", "items": list(items)})
+            first = False
+            items.clear()
+
+    for ln in lines:
+        if _BULLET_LINE.match(ln):
+            flush_text()
+            items.append(_BULLET_LINE.sub("", ln, count=1).strip())
+        elif ln.strip():
+            flush_items()
+            buf.append(ln)
+        else:
+            buf.append(ln)  # blank line — stays in whichever prose run is open
+    flush_items()
+    flush_text()
+    return out or [blk]
+
+
+def _repair_pipe_tables(blk: dict) -> list[dict]:
+    """Split a prose block containing a markdown pipe-table run into prose + table blocks."""
+    if blk.get("type") == "group":
+        return [dict(blk, blocks=[rb for b in blk.get("blocks", [])
+                                  for rb in _repair_pipe_tables(b)])]
+    if blk.get("type") == "columns":
+        return [dict(blk,
+                     left=[rb for b in blk.get("left", []) for rb in _repair_pipe_tables(b)],
+                     right=[rb for b in blk.get("right", []) for rb in _repair_pipe_tables(b)])]
+    if btype(blk) in ("list", "checklist"):
+        # A pipe table inside a bullet item: split the list around it and lift the table out.
+        out: list[dict] = []
+        cur: list = []
+        for item in blk.get("items", []):
+            if isinstance(item, str) and _INLINE_SEP.search(item):
+                pieces = _repair_pipe_tables({"type": "paragraph", "text": item})
+                if any(p.get("type") == "table" for p in pieces):
+                    if cur:
+                        out.append(dict(blk, items=cur))
+                        cur = []
+                    out.extend(pieces)
+                    continue
+            cur.append(item)
+        if cur:
+            out.append(dict(blk, items=cur))
+        return out or [blk]
+    if blk.get("type") not in ("paragraph", "labeled", "callout") \
+            or not isinstance(blk.get("text"), str):
+        return [blk]
+    text = blk["text"]
+    if "\n" not in text and _INLINE_SEP.search(text):
+        # Table collapsed onto one line — restore row boundaries ("| |" marks a row break).
+        text = re.sub(r"\|\s+\|", "|\n|", text)
+        blk = dict(blk, text=text)
+    lines = blk["text"].split("\n")
+    if any(_INLINE_SEP.search(ln) for ln in lines):
+        # Prose sharing a line with a table row would be swallowed into the table —
+        # split "intro text: | a | b |" and "| x | y | trailing text" onto separate lines.
+        norm: list[str] = []
+        for ln in lines:
+            m = re.match(r"^([^|]*[^|\s])\s*(\|.+\|)\s*$", ln)
+            if m and not _SEP_LINE.match(ln):
+                norm += [m.group(1), m.group(2)]
+                continue
+            m = re.match(r"^\s*(\|.+\|)\s*([^|]+)$", ln)
+            if m and not _SEP_LINE.match(ln):
+                norm += [m.group(1), m.group(2)]
+                continue
+            norm.append(ln)
+        lines = norm
+    out: list[dict] = []
+    buf: list[str] = []
+    i, first = 0, True
+
+    def flush():
+        nonlocal first
+        t = "\n".join(buf).strip()
+        if t:
+            out.append(dict(blk, text=t) if first else {"type": "paragraph", "text": t})
+            first = False
+        buf.clear()
+
+    while i < len(lines):
+        if _PIPE_LINE.search(lines[i]):
+            j = i
+            while j < len(lines) and (_PIPE_LINE.search(lines[j]) or _SEP_LINE.match(lines[j])):
+                j += 1
+            if sum(1 for k in range(i, j) if not _SEP_LINE.match(lines[k])) >= 2:
+                flush()
+                rows = _parse_pipe_rows(lines[i:j])
+                out.append({"type": "table", "headers": rows[0],
+                            "rows": rows[1:] or [[""] * len(rows[0])]})
+                first = False
+                i = j
+                continue
+        buf.append(lines[i])
+        i += 1
+    flush()
+    return out or [blk]
+
+
+def _doc_text(sections: list[dict]) -> str:
+    parts: list[str] = []
+
+    def walk(v):
+        if isinstance(v, str):
+            parts.append(v)
+        elif isinstance(v, list):
+            for x in v:
+                walk(x)
+        elif isinstance(v, dict):
+            for x in v.values():
+                walk(x)
+
+    walk(sections)
+    return "\n".join(parts)
+
+
+
+# Keys in `shared` that are document/identity metadata, never expanded as content blocks.
+_IDENTITY_KEYS = {"grade", "subject", "duration", "curriculum", "standard_code",
+                  "standard_text", "prerequisite_standard", "smps"}
+
+
+def _is_block(v) -> bool:
+    return isinstance(v, dict) and ("type" in v or "blocks" in v)
+
+
+def _as_blocks(v) -> list[dict]:
+    """Coerce a shared-registry value into renderer blocks. Accepts a block dict, a list of
+    block dicts, a typeless dict carrying the text/label/items field shapes (the schema's
+    stable contract — a `{label, text}` value renders as a labeled block, never as its
+    Python repr), or anything else (-> a single paragraph)."""
+    if v is None or v == "":
+        return []
+    if _is_block(v):
+        return [v]
+    if isinstance(v, dict) and v.get("items"):
+        return [{"type": "list", **{k: v[k] for k in ("label", "items") if k in v}}]
+    if isinstance(v, dict) and v.get("text"):
+        btype = "labeled" if v.get("label") else "paragraph"
+        return [{"type": btype, **{k: v[k] for k in ("label", "text") if k in v}}]
+    if isinstance(v, list) and v and all(_is_block(x) for x in v):
+        return list(v)
+    if isinstance(v, list):
+        return [{"type": "list", "items": [str(x) for x in v]}]
+    return [{"type": "paragraph", "text": str(v)}]
+
+
+def _facet_text(v) -> str:
+    """Flatten a plain facet (string / paragraph / list blocks) to text, or '' if it
+    contains richer blocks that should render as-is."""
+    blocks = _as_blocks(v)
+    if not blocks or not all(b.get("type") in ("paragraph", "list") for b in blocks):
+        return ""
+    return "\n".join(b.get("text", "") if b.get("type") == "paragraph"
+                     else "\n".join(f"- {it}" for it in b.get("items", []))
+                     for b in blocks)
+
+
+def _faceted(val: dict, audience: str) -> list[dict]:
+    """Expand a {teacher?, student?, stimulus?} value.
+
+    Student pages: student facet, then stimulus — the worksheet reads task-then-surface —
+    and nothing else: teacher script never reaches the worksheet, and a null/absent
+    student facet renders nothing (so oral/teacher-led tasks leave no trace).
+
+    Teacher pages: stimulus + teacher facet as plain script, then the
+    student facet as ONE quoted "Students see" line — the teacher reads their own script and
+    the exact prompt students will work from, the way a printed teacher edition shows both.
+    Neither facet is a callout: callouts are reserved for the few moments a teacher must not
+    miss, and a page where every task is boxed highlights nothing."""
+    out: list[dict] = list(_as_blocks(val.get("stimulus")))
+    if audience != "teacher":
+        out[:0] = _as_blocks(val.get("student"))
+        return out
+    t_blocks = _as_blocks(val.get("teacher"))
+    if len(t_blocks) == 1 and t_blocks[0].get("type") == "list":
+        # A list-form script renders as a real list — one glanceable move per line —
+        # not a paragraph with dash-prefixed lines.
+        out.append(t_blocks[0])
+    else:
+        t = _facet_text(val.get("teacher"))
+        if t:
+            out.append({"type": "instructions", "text": t})
+        else:
+            out.extend(t_blocks)
+    s = _facet_text(val.get("student"))
+    if s:
+        out.append({"type": "labeled", "label": "Students see", "text": s})
+    else:
+        out.extend(_as_blocks(val.get("student")))
+    return out
+
+
+def expand_from_shared(key: str, shared: dict, audience: str = "teacher",
+                       blk: dict | None = None) -> list[dict]:
+    """Expand a `{"type": "from_shared", "key": ...}` block into plain renderer blocks.
+
+    The registry is freeform: any key the model registered in `shared` resolves the same way.
+    The only special case is `standard`, which is stored under `standard_code`/`standard_text`
+    rather than a single key.
+
+    audience: "teacher" (lesson plan / observation) or "student" (worksheet).
+    blk: the originating from_shared block — carries an optional `label` for numbered tasks.
+    """
+    shared = dict(shared or {})
+    if key == "standard":
+        if not (shared.get("standard_text") or shared.get("standard_code")):
+            return []
+        return [{"type": "callout", "kind": "special",
+                 "label": f"{shared.get('standard_code', '')} — Target standard".strip(" —"),
+                 "text": shared.get("standard_text", "")}]
+
+    val = shared.get(key)
+    if val is None or val == "" or val == []:
+        return []
+    if key in _IDENTITY_KEYS:
+        return [{"type": "paragraph", "text": str(val)}]
+
+    if isinstance(val, dict) and not _is_block(val) and (
+            "teacher" in val or "student" in val or "stimulus" in val):
+        out = _faceted(val, audience)
+    else:
+        out = _as_blocks(val)
+
+    # `{type: from_shared, key: p1, label: "1"}` — fold the label into the first text-bearing
+    # block (scanning past leading diagram blocks, which have nothing to fold into) so a
+    # numbered prompt renders on one line, not an orphan number above a paragraph.
+    # A label must never render alone. Dispatch on that block's FIELDS, not its
+    # type name — type names change (callout -> instructions broke the old version of
+    # this); the text/label/items field shapes are the schema's stable contract.
+    label = (blk or {}).get("label")
+    if label and out:
+        i = next((j for j, b in enumerate(out)
+                  if b.get("label") or b.get("text") or b.get("items")), 0)
+        first = out[i]
+        if first.get("label"):
+            out[i] = {**first, "label": f"{label}. {first['label']}"}
+        elif first.get("text"):
+            out[i] = {"type": "labeled", "label": str(label), "text": first["text"]}
+        elif first.get("items"):
+            items = list(first["items"])
+            out[i] = {"type": "labeled", "label": str(label), "text": str(items[0])}
+            if items[1:]:
+                out.insert(i + 1, {**first, "items": items[1:]})
+        else:
+            out.insert(i, {"type": "labeled", "label": str(label), "text": ""})
+    return out
+
+
+def expand_blocks(blocks: list, shared: dict, audience: str = "teacher") -> list[dict]:
+    """Replace any from_shared blocks in a block list (recursing into columns and groups)."""
+    out: list[dict] = []
+    for blk in blocks or []:
+        btype = blk.get("type")
+        if btype == "from_shared":
+            out.extend(expand_from_shared(blk.get("key", ""), shared, audience, blk))
+        elif btype == "columns":
+            out.append({"type": "columns",
+                        "left": expand_blocks(blk.get("left", []), shared, audience),
+                        "right": expand_blocks(blk.get("right", []), shared, audience)})
+        elif btype == "group":
+            out.append({**blk, "blocks": expand_blocks(blk.get("blocks", []), shared, audience)})
+        else:
+            out.append(blk)
+    return out
+
+
+_PROMPT_TYPES = ("paragraph", "labeled", "callout", "list", "h3")
+
+
+def _pair_writing_space(blocks: list[dict]) -> list[dict]:
+    """Glue a prompt block to the workspace/answer_box that follows it so a page break can
+    never separate a question from its writing space (renderers keep groups together).
+    Types are compared post-alias (btype) so canonical and legacy names both pair."""
+    out: list[dict] = []
+    i = 0
+    while i < len(blocks):
+        b = blocks[i]
+        if (btype(b) in _PROMPT_TYPES and i + 1 < len(blocks)
+                and btype(blocks[i + 1]) == "workspace"):
+            out.append({"type": "group", "blocks": [b, blocks[i + 1]]})
+            i += 2
+            continue
+        out.append(b)
+        i += 1
+    return out
+
+
+def _strip_heading_echo(section: dict) -> dict:
+    """Drop a leading repeat of the section heading from the first text block —
+    'If you finish early' + text starting 'If you finish early: …' prints twice."""
+    heading = str(section.get("heading", "")).strip().rstrip(":").strip()
+    blocks = section.get("blocks") or []
+    if not heading or len(heading) < 4 or not blocks:
+        return section
+    first = blocks[0]
+    btype = first.get("type")
+    target = first if btype in ("paragraph", "labeled", "callout") else None
+    if btype == "group" and first.get("blocks"):
+        inner = first["blocks"][0]
+        target = inner if inner.get("type") in ("paragraph", "labeled", "callout") else None
+    if not target or not isinstance(target.get("text"), str):
+        return section
+    m = re.match(r"\s*\**" + re.escape(heading) + r"\**\s*[:!.—–-]\s*", target["text"],
+                 re.IGNORECASE)
+    if not m or not target["text"][m.end():].strip():
+        return section
+    fixed = dict(target, text=target["text"][m.end():])
+    if btype == "group":
+        new_first = dict(first, blocks=[fixed] + first["blocks"][1:])
+    else:
+        new_first = fixed
+    return {**section, "blocks": [new_first] + blocks[1:]}
+
+
+def expand_document(data: dict, audience: str = "teacher") -> dict:
+    """Return a copy of a document dict with all from_shared blocks expanded."""
+    shared = data.get("shared", {})
+    doc = dict(data)
+    doc["sections"] = [
+        {**s, "blocks": expand_blocks(s.get("blocks", []), shared, audience)}
+        for s in data.get("sections", [])
+    ]
+    # Print-safety repair pass — post-expansion so it covers model prose AND shared content,
+    # in every artifact and both output formats (HTML and docx render through here).
+    doc["sections"] = [
+        {**s, "blocks": _pair_writing_space(
+            [rb for b in s.get("blocks", [])
+             for eb in _repair_enum_breaks(b)
+             for tb in _repair_pipe_tables(eb)
+             for rb in _repair_inline_bullets(tb)])}
+        for s in doc["sections"]
+    ]
+    doc["sections"] = [_strip_heading_echo(s) for s in doc["sections"]]
+    text = _doc_text(doc["sections"])
+    if UNKNOWN_SYMBOL in text and not _UNKNOWN_DEFINED.search(text):
+        for s in doc["sections"]:
+            if UNKNOWN_SYMBOL in _doc_text([s]):
+                s.setdefault("blocks", []).append(
+                    {"type": "paragraph",
+                     "text": "*The symbol ■ stands for the unknown number.*"})
+                break
+    return doc
+
+
+# ============================================================================
+# Shared rendering primitives — format-agnostic helpers used by every renderer.
+# Moved from render_lesson_html.py so render_lesson_docx.py can import the same
+# theme, alias, callout, and grade-band logic without duplication.
+# ============================================================================
+
+DEFAULT_THEME = {
+    "primary": "#17A267", "title_color": "#14613F",
+    "text": "#222222", "muted": "#666666", "rule": "#D0D4D8", "border": "#CBD2D8",
+    "title_size": 22, "body_size": 10.5,
+}
+HEX = re.compile(r"^#[0-9A-Fa-f]{3,8}$")
+
+# Legacy block-type names -> canonical names. Keeps existing lesson JSONs rendering.
+ALIASES = {"subheading": "h3", "bullets": "list", "answer_box": "workspace",
+           "data_table": "table",
+           # frame_bank retired as a component: legacy JSON renders as a plain
+           # labeled list — sentence supports are ordinary text the model
+           # composes, not a boxed special.
+           "frame_bank": "list"}
+
+
+def btype(blk: dict) -> str:
+    t = blk.get("type") or "paragraph"
+    return ALIASES.get(t, t)
+
+
+# Callout kinds: semantic name -> (icon, css class). Legacy `style`/`role` values map in.
+CALLOUT_KINDS = {
+    "special":      ("⭐", "special"),
+    "student-task": ("📌", "task"),
+    "teacher-note": ("✋", "tnote"),
+    "student-note": ("✋", "snote"),
+}
+CALLOUT_ALIASES = {
+    "accent": "special", "standard": "special",
+    "info": "student-task", "activity": "student-task",
+    "note": "teacher-note", "tip": "teacher-note",
+    "warning": "teacher-note", "caution": "teacher-note", "important": "special",
+}
+
+
+def resolve_callout_kind(blk: dict) -> str:
+    raw = str(blk.get("kind") or blk.get("role") or blk.get("style") or "student-task").lower()
+    return raw if raw in CALLOUT_KINDS else CALLOUT_ALIASES.get(raw, "student-task")
+
+
+class Theme:
+    def __init__(self, overrides: dict | None):
+        t = dict(DEFAULT_THEME)
+        t.update(overrides or {})
+        self.raw = t
+        self.answer_height, self.answer_gap, self.answer_row = 120.0, 22.0, 96.0
+        self.ruled_default = False
+        self.student_doc = False
+
+    def safe(self, key: str) -> str:
+        val = str(self.raw.get(key, DEFAULT_THEME.get(key, "")))
+        return val if HEX.match(val) else str(DEFAULT_THEME.get(key, "#222222"))
+
+
+def meta_text(meta) -> str:
+    """Normalize `meta` to a display string. The schema says it's a string, but models
+    sometimes emit a list of {label, value} dicts — join those as 'Label: value · …'."""
+    if isinstance(meta, dict):
+        meta = [meta]
+    if isinstance(meta, (list, tuple)):
+        parts = []
+        for item in meta:
+            if isinstance(item, dict):
+                label = str(item.get("label") or "").rstrip(":").strip()
+                value = str(item.get("value") or item.get("text") or "").strip()
+                parts.append(f"{label}: {value}" if label and value else (value or label))
+            elif item:
+                parts.append(str(item))
+        return " · ".join(p for p in parts if p)
+    return str(meta) if meta else ""
+
+
+def grade_number(data: dict):
+    """Best-effort grade parse: 0 for K, 1-12, or None."""
+    shared = data.get("shared") or {}
+    for src in (data.get("grade"), shared.get("grade") if isinstance(shared, dict) else None):
+        s = str(src or "").strip().lower()
+        if not s:
+            continue
+        if s.startswith("k") or "kind" in s:
+            return 0
+        m = re.search(r"\d{1,2}", s)
+        if m:
+            return int(m.group(0))
+    for which, src in (("eyebrow", data.get("eyebrow")), ("meta", meta_text(data.get("meta")))):
+        s = str(src or "").lower()
+        if "kindergarten" in s:
+            return 0
+        m = (re.search(r"\bgrade[:\s]*(k|\d{1,2})\b", s)
+             or re.search(r"\b(\d{1,2})(?:st|nd|rd|th)[\s-]*grade\b", s))
+        if not m and which == "eyebrow":
+            m = re.search(r"^\s*(k|1[0-2]|[1-9])(?:st|nd|rd|th)?\b"
+                          r"(?!\s*(?:min|minute|hour|problem|tier|page|point|task|question))", s)
+        if m:
+            g = m.group(1)
+            return 0 if g == "k" else int(g)
+    return None
+
+
+def answer_profile(data: dict) -> tuple:
+    """Grade-banded writing-space defaults:
+    (height pt, ruled line gap pt, table-row pt, ruled by default).
+
+    Math work space is open by default; a block's explicit `ruled: true`
+    still gets the band's gap, so a grade-1 sentence answer gets K-2 pitch."""
+    n = grade_number(data)
+    if n is None:
+        return 120.0, 22.0, 96.0, False
+    shared = data.get("shared")
+    shared = shared if isinstance(shared, dict) else {}
+    # smps (Standards for Mathematical Practice) is the most reliable math signal — it is
+    # math-only and the math reference mandates it, whereas shared.subject is often omitted.
+    is_math = bool(shared.get("smps")) or "math" in " ".join(str(x or "") for x in (
+        shared.get("subject"), data.get("eyebrow"), data.get("title"))).lower()
+    if n <= 2:
+        return 200.0, 40.0, 160.0, not is_math
+    if n <= 5:
+        return 150.0, 28.0, 126.0, not is_math
+    if n <= 8:
+        return 130.0, 24.0, 108.0, False
+    return 116.0, 22.0, 96.0, False
+
+
+def coerce_marks(raw):
+    """Number-line marks: bare numbers or {position/value, label} dicts -> [(value, label)].
+    Models write both forms; a mark the renderer can't read must never vanish silently —
+    a task that says "the point for 1/6 is shown" depends on it being drawn."""
+    out = []
+    for m in raw or []:
+        if isinstance(m, (int, float)) and not isinstance(m, bool):
+            out.append((float(m), None))
+        elif isinstance(m, dict):
+            v = m.get("position", m.get("value", m.get("x")))
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                lab = m.get("label")
+                out.append((float(v), str(lab) if lab not in (None, "") else None))
+    return out
+
+
+WORKSPACE_SIZES = {"small": 70.0, "med": 130.0, "large": 220.0}
+FILL_IN_CHARS = {"short": 12, "med": 28, "long": 60}  # underscore counts for non-CSS formats
+
+
+def workspace_height(blk: dict, theme: Theme) -> float:
+    """Resolve a workspace block's height in points (format-agnostic)."""
+    h = blk.get("height_pt")
+    if h is None:
+        h = WORKSPACE_SIZES.get(str(blk.get("size", "")).lower())
+    if h is None:
+        h = theme.answer_height
+    try:
+        return float(h)
+    except (TypeError, ValueError):
+        return float(theme.answer_height)
+
+
+def label_text(blk: dict) -> str:
+    """Normalized label string — strips a trailing colon so renderers can add their own
+    consistently without doubling it."""
+    return str(blk.get("label", "")).rstrip(":")
+
+
+def label_sep(label: str) -> str:
+    """Separator after a label: numeric labels (task numbers like "1", "2a") get a period;
+    word labels ("Anchor task", "Exit ticket") get a colon. A label that already ends in a
+    period gets no extra separator."""
+    s = label.strip()
+    if s.endswith("."):
+        return ""
+    return "." if re.fullmatch(r"\d+[a-z]?", s, re.IGNORECASE) else ":"
+
+
+def normalize_text(text) -> str:
+    """Format-agnostic text fixups applied before any inline-markdown parse."""
+    t = str(text)
+    t = re.sub(r"(?<!_)_{3,9}(?!_)", "______", t)
+    t = re.sub(r"\s+\|\s+", " · ", t)
+    return t
+
+
+_MD_TOKEN = re.compile(r"(\*\*.+?\*\*|(?<!\*)\*(?!\s).+?(?<!\s)\*(?!\*)|\n)")
+
+
+def md_tokens(text) -> list:
+    """Parse mini-markdown into format-neutral tokens.
+
+    Returns a list of (text, attrs) where attrs is a dict with optional 'bold',
+    'italic', 'break' keys. normalize_text() is applied first."""
+    t = normalize_text(text)
+    out = []
+    for part in _MD_TOKEN.split(t):
+        if not part:
+            continue
+        if part == "\n":
+            out.append(("", {"break": True}))
+        elif part.startswith("**") and part.endswith("**"):
+            out.append((part[2:-2], {"bold": True}))
+        elif part.startswith("*") and part.endswith("*"):
+            out.append((part[1:-1], {"italic": True}))
+        else:
+            out.append((part, {}))
+    return out
+
+
+def coerce_rows(rows) -> list[list]:
+    """Normalize model-emitted table rows. Each row must be a list of cells, but models
+    sometimes emit a bare string ("Total: $5.99"), a dict ({"label": ..., "value": ...}),
+    or null — coerce instead of crashing (docx KeyError) or garbling (one cell per
+    character); null becomes a blank write-in row."""
+    if isinstance(rows, str):
+        # The whole rows value drawn as one pipe string — restore rows and cells.
+        rows = _parse_pipe_rows(rows.splitlines()) if "|" in rows else [[rows]]
+    out: list[list] = []
+    for r in rows or []:
+        if isinstance(r, list):
+            out.append(r)
+        elif isinstance(r, dict):
+            out.append(list(r.values()))
+        elif r is None:
+            out.append([])
+        else:
+            out.append([str(r)])
+    return out
+
+
+def coerce_headers(headers) -> list:
+    """Normalize table headers. A bare string ("Item | Cost") is the pipe-joined header
+    row a model meant — split it; a dict's values are its labels; any other non-list
+    becomes a single header."""
+    if isinstance(headers, list):
+        return headers
+    if not headers:
+        return []
+    if isinstance(headers, dict):
+        return list(headers.values())
+    s = str(headers)
+    if "|" in s:
+        parsed = _parse_pipe_rows([s])
+        return parsed[0] if parsed else []
+    return [s]
+
+
+def table_row_height(blk: dict, theme: Theme, *, full_blank: bool) -> float:
+    """Minimum height (pt) for a table row containing empty writing-space cells.
+    An explicit empty_row_height_pt / row_height_pt wins (floored at the 40pt
+    writable minimum the deterministic checks enforce) — a sort grid whose cells
+    take an X is deliberately shorter than a sentence row, and flooring it to
+    the grade band printed near-blank pages of grid. The band sizes rows only
+    when the model didn't say."""
+    try:
+        explicit = float(blk.get("empty_row_height_pt")
+                         or blk.get("row_height_pt") or 0)
+    except (TypeError, ValueError):
+        explicit = 0.0
+    band = theme.answer_row
+    if theme.student_doc:
+        if explicit:
+            return max(explicit, 40.0)
+        return band if full_blank else 0.45 * band
+    return explicit or 36.0
+
+
+def preamble_blocks(data: dict) -> list[dict]:
+    """Top-level standard / prerequisite / practices blocks rendered between the header
+    and the first section. Shared by both formats so the preamble can never drift."""
+    blocks: list[dict] = []
+    if data.get("standard_text"):
+        label = f"{data.get('standard_code', '')} — Target standard".strip(" —")
+        blocks.append({"type": "callout", "kind": "special", "label": label,
+                       "text": data["standard_text"]})
+    if data.get("prerequisite_standard"):
+        blocks.append({"type": "labeled", "label": "Builds on",
+                       "text": data["prerequisite_standard"]})
+    if data.get("smps"):
+        blocks.append({"type": "labeled", "label": "Mathematical practices",
+                       "text": "; ".join(data["smps"])})
+    return blocks
+
+
+def build_header(data: dict) -> dict:
+    """Format-agnostic header fields: eyebrow, title, meta string, optional name_line."""
+    meta = meta_text(data.get("meta"))
+    if not meta:
+        bits = [data.get("standard_code"), data.get("grade"), data.get("duration"),
+                data.get("curriculum")]
+        if data.get("materials"):
+            bits.append("Materials: " + ", ".join(data["materials"]))
+        meta = " · ".join(str(b) for b in bits if b)
+    name_line = ""
+    if meta and data.get("audience") == "student" and re.search(r"name\s*:", meta, re.I):
+        name_line, meta = meta, ""
+    return {"eyebrow": data.get("eyebrow", ""), "title": data.get("title", "Lesson Plan"),
+            "meta": meta, "name_line": name_line}

--- a/skill-library/k12-lesson-planning/scripts/render_all.sh
+++ b/skill-library/k12-lesson-planning/scripts/render_all.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+# Render every document in lesson.json (lesson plan, student materials, observation, and any
+# others the model authored) from one material-source JSON. It holds a `documents[]` array;
+# each entry's `id` becomes the output filename. Writes editable .docx (the teacher
+# deliverable) and an .html twin of each (a preview that renders even without python-docx).
+# Fail-fast: any renderer error stops the run.
+#
+# Usage: bash scripts/render_all.sh lesson.json "$OUTPUT_DIR"
+set -euo pipefail
+
+json="${1:?usage: render_all.sh LESSON_JSON OUTPUT_DIR}"
+outdir="${2:?usage: render_all.sh LESSON_JSON OUTPUT_DIR}"
+here="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p "$outdir"
+# python-docx powers the .docx output; the .html twins render without it. If the install
+# can't complete (offline container), render html now so the twins always exist.
+if ! python3 -c "import docx" 2>/dev/null; then
+  python3 -m pip install -q "python-docx==1.1.2" || true
+fi
+if python3 -c "import docx" 2>/dev/null; then
+  python3 "$here/render_documents.py" "$json" --format both --outdir "$outdir"
+else
+  # Render the html twins so a readable preview still exists, then fail loudly: the
+  # teacher's .docx deliverables could not be produced.
+  python3 "$here/render_documents.py" "$json" --format html --outdir "$outdir"
+  echo "error: python-docx could not be installed — no .docx deliverables were produced" >&2
+  exit 1
+fi
+# Persist the source JSON alongside the rendered artifacts so later revision
+# turns can re-render from it.
+cp "$json" "$outdir/lesson.json" 2>/dev/null || true
+
+# Delivery guarantee: when $OUTPUT_DIR is set and the render went elsewhere
+# (a staging dir like /tmp/out), mirror EVERYTHING into $OUTPUT_DIR too.
+# Revision turns re-render from the lesson.json that lands there;
+# hand-copying a subset there is the failure this removes.
+if [ -n "${OUTPUT_DIR:-}" ] && [ "$(cd "$outdir" && pwd)" != "$(mkdir -p "$OUTPUT_DIR" && cd "$OUTPUT_DIR" && pwd)" ]; then
+  cp -R "$outdir"/. "$OUTPUT_DIR"/
+fi

--- a/skill-library/k12-lesson-planning/scripts/render_documents.py
+++ b/skill-library/k12-lesson-planning/scripts/render_documents.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render every document in a multi-document source JSON (HTML previews and/or editable .docx).
+
+Used by skills whose output is a set of documents that must stay consistent with each other
+(e.g. the differentiation skills: 1 teacher plan + 3 tiered worksheets). The source JSON holds
+ONE `shared` block (content that appears in more than one document) plus a `documents` array.
+Each document is a full block-document — same schema as render_lesson_html.py /
+render_lesson_docx.py (eyebrow / title / meta / sections / theme / audience) — and pulls shared
+content with {"type": "from_shared", "key": ...} blocks, so shared content is written once and
+cannot drift between documents.
+
+Material source shape:
+  {
+    "shared": {"standard_code": ..., "standard_text": ...,
+               <any model-chosen keys: a block, a list of blocks, or a faceted
+                {teacher, student, stimulus} value>, ...},
+    "theme": {...},                              // default theme for every document
+    "documents": [
+      {"id": "teacher_plan",      "audience": "teacher", "title": ..., "sections": [...]},
+      {"id": "worksheet_group_a", "audience": "student", "title": ..., "sections": [...]},
+      {"id": "worksheet_group_b", "audience": "student", "title": ..., "sections": [...]},
+      {"id": "worksheet_group_c", "audience": "student", "title": ..., "sections": [...]}
+    ]
+  }
+
+`id` becomes the output filename; a document's own `theme` overrides the top-level one.
+
+Usage:
+    python render_documents.py differentiation.json --format html             # all docs -> HTML previews
+    python render_documents.py differentiation.json --format docx             # all docs -> editable .docx
+    python render_documents.py differentiation.json --only worksheet_group_a worksheet_group_b --format docx
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def build_doc(source: dict, doc: dict) -> dict:
+    """Merge a document entry with the source's shared block and default theme."""
+    out = dict(doc)
+    out.setdefault("shared", source.get("shared", {}))
+    theme = dict(source.get("theme") or {})
+    theme.update(doc.get("theme") or {})
+    if theme:
+        out["theme"] = theme
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("input", help="source JSON with a `documents` array")
+    ap.add_argument("--format", choices=["html", "docx", "both"], default="html")
+    ap.add_argument("--only", nargs="*", default=None,
+                    help="document ids to render (default: all)")
+    ap.add_argument("--outdir", default=".")
+    args = ap.parse_args()
+
+    source = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    docs = source.get("documents", [])
+    if not docs:
+        print("error: no `documents` array in input", file=sys.stderr)
+        return 1
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    written = []
+    for i, doc in enumerate(docs):
+        # Sanitize the document id before it becomes a filename: the id comes from generated
+        # JSON, so strip path separators and anything outside [A-Za-z0-9_-].
+        doc_id_raw = str(doc.get("id") or f"document_{i + 1}")
+        doc_id = re.sub(r"[^A-Za-z0-9_\-]", "_", Path(doc_id_raw).name) or f"document_{i + 1}"
+        if args.only and doc_id_raw not in args.only and doc_id not in args.only:
+            continue
+        full = build_doc(source, doc)
+        # The HTML twin always ships — docx is the teacher deliverable, html is its
+        # always-available preview. Rendering docx alone leaves the twin missing, so
+        # "docx" implies both.
+        from render_lesson_html import render as render_html
+        path = outdir / f"{doc_id}.html"
+        path.write_text(render_html(full), encoding="utf-8")
+        written.append(str(path))
+        if args.format in ("docx", "both"):
+            from render_lesson_docx import render as render_docx
+            path = outdir / f"{doc_id}.docx"
+            render_docx(full, str(path))
+            written.append(str(path))
+
+    if not written:
+        print("nothing rendered — check --only ids against the documents' `id` fields",
+              file=sys.stderr)
+        return 1
+    print("wrote " + ", ".join(written))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skill-library/k12-lesson-planning/scripts/render_lesson_docx.py
+++ b/skill-library/k12-lesson-planning/scripts/render_lesson_docx.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render lesson JSON -> an editable .docx (the teacher-editable deliverable).
+
+Same input schema and block vocabulary as render_lesson_html.py; consumes the same
+expand_document() / theme / alias / callout-kind helpers from lesson_common, so the two
+formats stay in sync by construction. Styling follows the same visual design principles:
+minimal color, icon-prefixed callouts (no fill), B+W-safe.
+
+Usage:
+    python render_lesson_docx.py lesson.json -o lesson_plan.docx
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lesson_common import (  # noqa: E402
+    Theme, CALLOUT_KINDS, FILL_IN_CHARS, btype as _btype,
+    resolve_callout_kind, answer_profile, build_header, expand_document, coerce_marks,
+    md_tokens, workspace_height, label_text, label_sep, table_row_height, preamble_blocks,
+    coerce_headers, coerce_rows,
+)
+
+try:
+    from docx import Document
+    from docx.shared import Pt, RGBColor, Inches
+    from docx.enum.text import WD_TAB_ALIGNMENT, WD_BREAK, WD_ALIGN_PARAGRAPH
+    from docx.enum.table import WD_ROW_HEIGHT_RULE
+    from docx.oxml.ns import qn
+    from docx.oxml import OxmlElement
+except ImportError:  # pragma: no cover
+    print("error: python-docx is required — pip install \"python-docx==1.1.2\"",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+# ---- styles ------------------------------------------------------------------
+
+def _hex_rgb(hex_str: str) -> RGBColor:
+    h = hex_str.lstrip("#")
+    if len(h) in (3, 4):  # expand short hex (#1a7 -> #11aa77); HEX in lesson_common accepts 3-8 chars
+        h = "".join(c * 2 for c in h[:3])
+    h = (h + "000000")[:6]
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def setup_styles(doc, theme: Theme):
+    body = float(theme.raw.get("body_size", 10.5))
+    s = doc.styles
+    s["Normal"].font.name = "Helvetica"
+    s["Normal"].font.size = Pt(body)
+    # Pin Normal to the html stylesheet's 8pt-after; otherwise Word's template
+    # default of 10pt-after leaks into every plain paragraph.
+    s["Normal"].paragraph_format.space_before = Pt(0)
+    s["Normal"].paragraph_format.space_after = Pt(8)
+    for name, size, bold, color, before, after in [
+        ("LC Eyebrow", 9, True, theme.safe("primary"), 0, 2),
+        ("LC Title", float(theme.raw.get("title_size", 22)), True, theme.safe("text"), 2, 2),
+        ("LC Meta", 9, False, theme.safe("muted"), 0, 12),
+        ("LC H1", 14, True, theme.safe("text"), 18, 8),
+        ("LC H2", 12, True, theme.safe("primary"), 12, 4),
+        ("LC H3", body, True, theme.safe("text"), 8, 4),
+        ("LC Instr", body, False, theme.safe("text"), 4, 6),
+        ("LC Muted", 8.5, False, theme.safe("muted"), 4, 0),
+        ("LC Spacer", 2, False, theme.safe("muted"), 4, 0),
+    ]:
+        st = s.add_style(name, 1)  # 1 = WD_STYLE_TYPE.PARAGRAPH
+        st.base_style = s["Normal"]
+        st.font.size = Pt(size)
+        st.font.bold = bold
+        st.font.color.rgb = _hex_rgb(color)
+        st.paragraph_format.space_before = Pt(before)
+        st.paragraph_format.space_after = Pt(after)
+    s["LC Eyebrow"].font.all_caps = True
+    # The structural paragraph dropped after every table-rendered block (callout,
+    # cards, workspace, table) — OOXML wants a paragraph between consecutive
+    # tables. Exact 2pt line height keeps it from reading as a blank line.
+    s["LC Spacer"].paragraph_format.line_spacing = Pt(2)
+
+
+# ---- inline runs -------------------------------------------------------------
+
+def add_md(para, text, bold=False, italic=False):
+    """Add mini-markdown text to a paragraph as runs."""
+    for t, attrs in md_tokens(text):
+        if attrs.get("break"):
+            para.add_run().add_break()
+            continue
+        r = para.add_run(t)
+        r.bold = bold or attrs.get("bold", False)
+        r.italic = italic or attrs.get("italic", False)
+
+
+# ---- table primitives --------------------------------------------------------
+
+def _set_borders(tbl, color="CBD2D8", sides=("top", "bottom", "left", "right",
+                                             "insideH", "insideV")):
+    pr = tbl._tbl.tblPr
+    borders = pr.find(qn("w:tblBorders"))
+    if borders is None:
+        borders = OxmlElement("w:tblBorders")
+        pr.append(borders)
+    for side in sides:
+        el = OxmlElement(f"w:{side}")
+        el.set(qn("w:val"), "single")
+        el.set(qn("w:sz"), "6")
+        el.set(qn("w:color"), color)
+        borders.append(el)
+
+
+def _set_cell_margins(tbl):
+    """Internal cell padding (twips; 100 twips = 5pt). Word's default top/bottom is 0,
+    which makes cell text sit flush against the top border in most viewers."""
+    pr = tbl._tbl.tblPr
+    mar = OxmlElement("w:tblCellMar")
+    for side, val in (("top", 100), ("bottom", 100), ("left", 120), ("right", 120)):
+        el = OxmlElement(f"w:{side}")
+        el.set(qn("w:w"), str(val))
+        el.set(qn("w:type"), "dxa")
+        mar.append(el)
+    pr.append(mar)
+
+
+def _cant_split(tbl):
+    """Mark every row as non-splitting so a table (callout, card row, data row) never
+    breaks across a page boundary mid-row."""
+    for row in tbl.rows:
+        trpr = row._tr.get_or_add_trPr()
+        trpr.append(OxmlElement("w:cantSplit"))
+
+
+def _shade_cell(cell, fill="F6F8F9"):
+    pr = cell._tc.get_or_add_tcPr()
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:fill"), fill)
+    pr.append(shd)
+
+
+def _list_number_abstract_id(doc) -> str | None:
+    """Return the abstractNumId that the built-in 'List Number' style binds to."""
+    try:
+        # _Cell has no .styles; resolve via the part (cell.part is the DocumentPart).
+        styles = doc.styles if hasattr(doc, "styles") else doc.part.document.styles
+        st = styles["List Number"].element
+        nid = st.find(qn("w:pPr")).find(qn("w:numPr")).find(qn("w:numId")).get(qn("w:val"))
+        for n in doc.part.numbering_part.element.findall(qn("w:num")):
+            if n.get(qn("w:numId")) == nid:
+                return n.find(qn("w:abstractNumId")).get(qn("w:val"))
+    except (AttributeError, KeyError):
+        pass
+    return None
+
+
+def _restart_numbering(doc, paras: list):
+    """Give an ordered list its own numId so it restarts at 1 instead of continuing
+    the previous one (python-docx's built-in 'List Number' style shares one numId
+    document-wide). Stamps EVERY paragraph in the list."""
+    abstract_id = _list_number_abstract_id(doc)
+    if abstract_id is None:
+        return
+    numbering = doc.part.numbering_part.element
+    nums = numbering.findall(qn("w:num"))
+    new_id = max(int(n.get(qn("w:numId"))) for n in nums) + 1
+    new = OxmlElement("w:num")
+    new.set(qn("w:numId"), str(new_id))
+    abst = OxmlElement("w:abstractNumId")
+    abst.set(qn("w:val"), abstract_id)
+    new.append(abst)
+    ovr = OxmlElement("w:lvlOverride")
+    ovr.set(qn("w:ilvl"), "0")
+    start = OxmlElement("w:startOverride")
+    start.set(qn("w:val"), "1")
+    ovr.append(start)
+    new.append(ovr)
+    numbering.append(new)
+    for p in paras:
+        npr = p._p.get_or_add_pPr().get_or_add_numPr()
+        npr.get_or_add_ilvl().val = 0
+        npr.get_or_add_numId().val = new_id
+
+
+def _keep_with_next(para):
+    para.paragraph_format.keep_with_next = True
+    para.paragraph_format.keep_together = True
+
+
+def _box(doc, theme: Theme):
+    """A 1x1 bordered table used for callouts."""
+    t = doc.add_table(rows=1, cols=1)
+    t.autofit = True
+    _set_borders(t, color=theme.safe("border").lstrip("#"),
+                 sides=("top", "bottom", "left", "right"))
+    _set_cell_margins(t)
+    _cant_split(t)
+    cell = t.rows[0].cells[0]
+    cell.paragraphs[0].text = ""
+    return cell
+
+
+def _content_width(doc) -> float:
+    """Usable text width in inches (page width minus margins)."""
+    s = doc.sections[0]
+    return (s.page_width - s.left_margin - s.right_margin) / 914400  # EMU per inch
+
+
+# ---- per-block emitters ------------------------------------------------------
+
+def _emit_paragraph(doc, blk, theme):
+    add_md(doc.add_paragraph(), blk.get("text", ""))
+
+
+def _emit_labeled(doc, blk, theme):
+    p = doc.add_paragraph()
+    lbl = label_text(blk)
+    add_md(p, f"{lbl}{label_sep(lbl)} ", bold=True)
+    add_md(p, blk.get("text", ""))
+
+
+def _emit_heading(style):
+    def _f(doc, blk, theme):
+        doc.add_paragraph(style=style).add_run(str(blk.get("text", "")))
+    return _f
+
+
+def _emit_instructions(doc, blk, theme):
+    add_md(doc.add_paragraph(style="LC Instr"), blk.get("text", ""))
+
+
+def _label_para(doc, blk):
+    # Hug the block it introduces (html .listlabel: 2pt below).
+    lp = doc.add_paragraph()
+    add_md(lp, label_text(blk), bold=True)
+    lp.paragraph_format.space_before = Pt(2)
+    lp.paragraph_format.space_after = Pt(2)
+
+
+def _emit_list(doc, blk, theme, *, checklist=False):
+    if blk.get("label"):
+        _label_para(doc, blk)
+    ordered = bool(blk.get("ordered"))
+    style = "List Number" if ordered else "List Bullet"
+    paras = []
+    for item in blk.get("items", []):
+        p = doc.add_paragraph(style=style)
+        if checklist:
+            p.add_run("☐  ")
+        add_md(p, item)
+        paras.append(p)
+    if ordered and paras:
+        _restart_numbering(doc, paras)
+
+
+def _emit_callout(doc, blk, theme):
+    kind = resolve_callout_kind(blk)
+    icon, _ = CALLOUT_KINDS[kind]
+    cell = _box(doc, theme)
+    lp = cell.paragraphs[0]
+    lp.add_run(icon + "  ")
+    if blk.get("label"):
+        add_md(lp, label_text(blk), bold=True)
+    text = blk.get("text") or blk.get("body") or blk.get("content") or ""
+    if text:
+        add_md(cell.add_paragraph(), text)
+    doc.add_paragraph(style="LC Spacer")
+
+
+def _emit_cards(doc, blk, theme):
+    items = blk.get("items", [])
+    if not items:
+        return
+    tbl = doc.add_table(rows=1, cols=len(items))
+    _set_borders(tbl, color=theme.safe("border").lstrip("#"))
+    _set_cell_margins(tbl)
+    _cant_split(tbl)
+    for i, c in enumerate(items):
+        c = c if isinstance(c, dict) else {"title": str(c), "text": ""}
+        cell = tbl.rows[0].cells[i]
+        add_md(cell.paragraphs[0], c.get("title", ""), bold=True)
+        add_md(cell.add_paragraph(), c.get("text", ""))
+    doc.add_paragraph(style="LC Spacer")
+
+
+def _emit_fill_in(doc, blk, theme):
+    n = FILL_IN_CHARS.get(str(blk.get("size", "med")).lower(), FILL_IN_CHARS["med"])
+    p = doc.add_paragraph()
+    if blk.get("label"):
+        add_md(p, label_text(blk) + ": ", bold=True)
+    p.add_run("_" * n)
+
+
+def _emit_phase_header(doc, blk, theme):
+    p = doc.add_paragraph(style="LC H2")
+    p.paragraph_format.keep_with_next = True
+    p.paragraph_format.tab_stops.add_tab_stop(Inches(theme.content_width),
+                                              WD_TAB_ALIGNMENT.RIGHT)
+    p.add_run(str(blk.get("name", "")))
+    if blk.get("minutes") is not None:
+        r = p.add_run(f"\t{blk['minutes']} min")
+        r.font.bold = False
+        r.font.color.rgb = _hex_rgb(theme.safe("muted"))
+
+
+def _emit_group(doc, blk, theme):
+    # A prompt or label never strands from the surface below it: text-bearing
+    # paragraphs keep with what follows. Spacers do NOT chain — a multi-surface
+    # question (two number lines + a box, 400pt+) as one atomic unit forces Word
+    # to jump whole questions to fresh pages, stranding half-blank pages.
+    before = len(doc.paragraphs) if hasattr(doc, "paragraphs") else None
+    for b in blk.get("blocks", []):
+        emit_block(doc, b, theme)
+    if before is not None:
+        for p in doc.paragraphs[before:-1]:
+            if p.text.strip():
+                _keep_with_next(p)
+
+
+def _emit_workspace(doc, blk, theme, *, labeled=False):
+    if labeled and blk.get("label"):
+        _label_para(doc, blk)
+    h = workspace_height(blk, theme)
+    if blk.get("ruled", theme.ruled_default):
+        # Ruled handwriting lines: one bottom-bordered table row per line — the
+        # same border mechanism the number lines use. Paragraph borders (pBdr)
+        # never rendered reliably in Word: property-order sensitive, and
+        # adjacent identically-bordered paragraphs merge into one box.
+        gap = float(theme.answer_gap)
+        n = max(2, int(round(h / gap)))
+        tbl = doc.add_table(rows=n, cols=1)
+        tbl.autofit = False
+        _cant_split(tbl)
+        for row in tbl.rows:
+            row.height = Pt(gap)
+            row.height_rule = WD_ROW_HEIGHT_RULE.AT_LEAST
+            _cell_borders(row.cells[0], ["bottom"], color="C9CFD4", sz="6")
+    else:
+        tbl = doc.add_table(rows=1, cols=1)
+        tbl.rows[0].height = Pt(h)
+        tbl.rows[0].height_rule = WD_ROW_HEIGHT_RULE.AT_LEAST
+        _set_borders(tbl, color="FFFFFF")
+    doc.add_paragraph(style="LC Spacer")
+
+
+def _emit_page_break(doc, blk, theme):
+    doc.add_paragraph().add_run().add_break(WD_BREAK.PAGE)
+
+
+def _emit_table(doc, blk, theme):
+    headers = coerce_headers(blk.get("headers"))
+    rows = coerce_rows(blk.get("rows"))
+    ncols = max(len(headers), max((len(r) for r in rows), default=1), 1)
+    tbl = doc.add_table(rows=0, cols=ncols)
+    _set_borders(tbl, color=theme.safe("border").lstrip("#"))
+    _set_cell_margins(tbl)
+    if headers:
+        hr = tbl.add_row()
+        hr._tr.get_or_add_trPr().append(OxmlElement("w:tblHeader"))
+        for i, h in enumerate(headers):
+            _shade_cell(hr.cells[i])
+            add_md(hr.cells[i].paragraphs[0], str(h).rstrip(": "), bold=True)
+    large = blk.get("display") == "large"
+    for r in rows:
+        tr = tbl.add_row()
+        cells = [str(r[i]) if i < len(r) else "" for i in range(ncols)]
+        # Underscore runs are write-in blanks, not text.
+        cells = ["" if c.strip().strip("_") == "" and "_" in c else c for c in cells]
+        full_blank = not any(c.strip() for c in cells)
+        for i, v in enumerate(cells):
+            p = tr.cells[i].paragraphs[0]
+            add_md(p, v, bold=(large and v.strip() != "")
+                   or (not headers and i == 0 and v.strip() != ""))
+            if large:
+                from docx.enum.text import WD_ALIGN_PARAGRAPH
+                p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+                for run in p.runs:
+                    run.font.size = Pt(18)
+        if any(not c.strip() for c in cells):
+            tr.height = Pt(table_row_height(blk, theme, full_blank=full_blank))
+            tr.height_rule = WD_ROW_HEIGHT_RULE.AT_LEAST
+    _cant_split(tbl)
+    doc.add_paragraph(style="LC Spacer")
+
+
+def _emit_columns(doc, blk, theme):
+    tbl = doc.add_table(rows=1, cols=2)
+    _set_borders(tbl, color="FFFFFF")
+    # A side-by-side comparison is one visual unit — never let Word split the row
+    # across a page boundary (a number line half on each page is unreadable).
+    _cant_split(tbl)
+    for side, cell in (("left", tbl.rows[0].cells[0]), ("right", tbl.rows[0].cells[1])):
+        for b in blk.get(side, []):
+            emit_block(cell, b, theme)
+
+
+def _emit_source_card(doc, blk, theme):
+    head = " · ".join(str(blk.get(k))
+                      for k in ("title", "author", "date", "origin") if blk.get(k))
+    _emit_callout(doc, {"kind": "student-task", "label": head,
+                        "text": blk.get("excerpt") or blk.get("text") or ""}, theme)
+
+
+def _emit_fill_table(doc, blk, theme):
+    headers = coerce_headers(blk.get("headers"))
+    try:
+        cols = max(1, len(headers) or int(blk.get("cols") or 2))
+    except (TypeError, ValueError):
+        cols = 2
+    cols = min(cols, 12)
+    rows_val = blk.get("rows")
+    if isinstance(rows_val, list):
+        # Mixed rows: a non-empty list renders its cells (a worked example);
+        # an empty list [] renders a blank write-in row.
+        rows = []
+        for r in coerce_rows(rows_val[:50]):
+            cells = r[:cols]
+            rows.append(cells + [""] * (cols - len(cells)))
+    else:
+        try:
+            n = int(blk.get("blank_rows") or rows_val or 3)
+        except (TypeError, ValueError):
+            n = 3
+        rows = [[""] * cols for _ in range(min(max(1, n), 50))]
+    fwd = {"headers": headers, "rows": rows}
+    for k in ("row_height_pt", "empty_row_height_pt"):
+        if blk.get(k):
+            fwd[k] = blk[k]
+    _emit_table(doc, fwd, theme)
+
+
+def _cell_borders(cell, sides, color="3A4046", sz="12"):
+    """Per-cell borders (the table-level helper paints every cell the same)."""
+    pr = cell._tc.get_or_add_tcPr()
+    borders = pr.find(qn("w:tcBorders"))
+    if borders is None:
+        borders = OxmlElement("w:tcBorders")
+        pr.append(borders)
+    for side in sides:
+        el = OxmlElement(f"w:{side}")
+        el.set(qn("w:val"), "single")
+        el.set(qn("w:sz"), sz)
+        el.set(qn("w:color"), color)
+        borders.append(el)
+
+
+def _emit_number_line(doc, blk, theme):
+    """A drawn number line, same geometry as the html twin: a horizontal bar with
+    evenly spaced tick marks and the min/max labeled at the ends. Built from a
+    borderless table — the segment cells' bottom borders form the line, their
+    left/right borders form the ticks — so students mark values on it by hand.
+
+    ticks=0 is a distinct "blank line" for student partitioning: the bar and its
+    end labels still draw, but with no tick marks at all, not even at the ends."""
+    try:
+        raw_ticks = None if blk.get("ticks") is None else int(blk.get("ticks"))
+    except (TypeError, ValueError):
+        raw_ticks = None
+    is_blank = raw_ticks == 0
+    ticks = 10 if raw_ticks is None else raw_ticks
+    ticks = min(max(1, ticks), 24)  # one cell per segment; 24 is plenty on paper
+    lo, hi = blk.get("min", 0), blk.get("max", 10)
+    marks = coerce_marks(blk.get("marks"))
+    try:
+        lo_f, hi_f = float(lo), float(hi)
+        span = hi_f - lo_f or 1.0
+    except (TypeError, ValueError):
+        lo_f, hi_f, span = 0.0, float(ticks), float(ticks)
+    eps = abs(span) * 0.002
+    marks = [(v, lab) for v, lab in marks
+             if abs(v - lo_f) > eps and abs(v - hi_f) > eps]
+
+    line_color = theme.safe("text").lstrip("#")
+    rows = 3 if marks else 2
+    # A single segment (ticks==1, or ticks==0 clamped to one) has only one bar but
+    # still needs two independently positioned end labels. A table cell can't hold
+    # two independently aligned runs reliably across docx viewers (a tab stop
+    # inside a merged cell doesn't render everywhere), so we always give the
+    # label row two real grid columns and merge them back into one cell for the
+    # bar/marks rows, which every docx viewer renders correctly.
+    single_segment = ticks == 1
+    cols = 2 if single_segment else ticks
+    tbl = doc.add_table(rows=rows, cols=cols)
+    tbl.autofit = False
+    _cant_split(tbl)
+    # cantSplit stops mid-row breaks; keep-with-next on every paragraph above the
+    # last row stops Word separating the line from its labels between rows.
+    for row in tbl.rows[:-1]:
+        for cell in row.cells:
+            for para in cell.paragraphs:
+                para.paragraph_format.keep_with_next = True
+    r = 0
+    if marks:
+        # A mark row above the line: label + ▼ centered over the nearest segment boundary.
+        mark_row = tbl.rows[0]
+        if single_segment:
+            mark_row.cells[0].merge(mark_row.cells[1])
+        for v, lab in marks:
+            seg = 0 if single_segment else min(ticks - 1, max(0, int(round((v - lo_f) / span * ticks))))
+            p = mark_row.cells[seg].paragraphs[0]
+            if lab:
+                r_lab = p.add_run(str(lab) + " ")
+                r_lab.bold = True
+                r_lab.font.size = Pt(8.5)
+            p.add_run("▼").bold = True
+            p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            p.paragraph_format.space_after = Pt(0)
+        r = 1
+    # The line row: bottom borders draw the bar, left/right borders draw the end
+    # ticks — omitted for a blank line, which shows only the bar and its labels.
+    line = tbl.rows[r]
+    line.height = Pt(22)  # room above the line for student marks
+    line.height_rule = WD_ROW_HEIGHT_RULE.AT_LEAST
+    if single_segment:
+        line_cell = line.cells[0].merge(line.cells[1])
+        sides = ["bottom"] + ([] if is_blank else ["left", "right"])
+        _cell_borders(line_cell, sides, color=line_color)
+        line_cell.paragraphs[0].paragraph_format.space_after = Pt(0)
+    else:
+        for i, cell in enumerate(line.cells):
+            sides = ["bottom", "left"] + (["right"] if i == ticks - 1 else [])
+            _cell_borders(cell, sides, color=line_color)
+            cell.paragraphs[0].paragraph_format.space_after = Pt(0)
+    # The label row: min under the first tick, max under the last — always two
+    # distinct grid cells, even for a single segment (see `cols` above).
+    labels = tbl.rows[r + 1]
+    lp = labels.cells[0].paragraphs[0]
+    add_md(lp, str(lo))
+    lp.paragraph_format.space_after = Pt(0)
+    rp = labels.cells[cols - 1].paragraphs[0]
+    add_md(rp, str(hi))
+    rp.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+    rp.paragraph_format.space_after = Pt(0)
+    doc.add_paragraph(style="LC Spacer")
+
+
+# Adding a block type or text field? Render it in render_lesson_html.py in the
+# same commit — the html and docx renderers must emit the same text.
+_EMITTERS = {
+    "paragraph": _emit_paragraph,
+    "labeled": _emit_labeled,
+    "h2": _emit_heading("LC H2"),
+    "h3": _emit_heading("LC H3"),
+    "instructions": _emit_instructions,
+    "list": _emit_list,
+    "checklist": lambda d, b, t: _emit_list(d, b, t, checklist=True),
+    "callout": _emit_callout,
+    "cards": _emit_cards,
+    "fill_in": _emit_fill_in,
+    "phase_header": _emit_phase_header,
+    "group": _emit_group,
+    "workspace": _emit_workspace,
+    "labeled_box": lambda d, b, t: _emit_workspace(d, b, t, labeled=True),
+    "page_break": _emit_page_break,
+    "table": _emit_table,
+    "columns": _emit_columns,
+    "source_card": _emit_source_card,
+    "fill_table": _emit_fill_table,
+    "number_line": _emit_number_line,
+}
+
+
+def emit_block(doc, blk: dict, theme: Theme):
+    fn = _EMITTERS.get(_btype(blk))
+    if fn is not None:
+        return fn(doc, blk, theme)
+    if blk.get("text"):
+        add_md(doc.add_paragraph(), blk["text"])
+    elif blk.get("items"):
+        for item in blk["items"]:
+            add_md(doc.add_paragraph(style="List Bullet"), item)
+
+
+# ---- document assembly -------------------------------------------------------
+
+def render(data: dict, out_path: str) -> int:
+    data = expand_document(data, data.get("audience", "teacher"))
+    theme = Theme(data.get("theme"))
+    (theme.answer_height, theme.answer_gap,
+     theme.answer_row, theme.ruled_default) = answer_profile(data)
+    theme.student_doc = data.get("audience") == "student"
+
+    doc = Document()
+    for s in doc.sections:
+        s.left_margin = s.right_margin = Inches(0.7)
+        s.top_margin = s.bottom_margin = Inches(0.6)
+    theme.content_width = _content_width(doc)
+    setup_styles(doc, theme)
+
+    hdr = build_header(data)
+    if hdr["eyebrow"]:
+        doc.add_paragraph(hdr["eyebrow"], style="LC Eyebrow")
+    doc.add_paragraph(hdr["title"], style="LC Title")
+    if hdr["meta"]:
+        doc.add_paragraph(hdr["meta"], style="LC Meta")
+    if hdr["name_line"]:
+        p = doc.add_paragraph()
+        add_md(p, hdr["name_line"])
+        p.paragraph_format.space_after = Pt(16)
+
+    for blk in preamble_blocks(data):
+        emit_block(doc, blk, theme)
+
+    for section in data.get("sections", []):
+        h1 = doc.add_paragraph(style="LC H1")
+        h1.paragraph_format.keep_with_next = True
+        h1.add_run(str(section.get("heading", "")).rstrip(": "))
+        for blk in section.get("blocks", []):
+            emit_block(doc, blk, theme)
+
+    if data.get("footer_note"):
+        doc.add_paragraph(str(data["footer_note"]), style="LC Muted")
+
+    doc.save(out_path)
+    # Post-expansion count, so multi-document sources report accurately.
+    return len(data.get("sections", []))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("input", help="lesson JSON file")
+    ap.add_argument("-o", "--output", default="lesson_plan.docx")
+    args = ap.parse_args()
+    data = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    render(data, args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skill-library/k12-lesson-planning/scripts/render_lesson_html.py
+++ b/skill-library/k12-lesson-planning/scripts/render_lesson_html.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# Copyright 2026 Anthropic, PBC
+# Copyright 2026 Learning Commons
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render lesson JSON -> a styled, self-contained HTML preview (the teacher-facing view).
+
+Visual design principles:
+  - Minimal color. Callouts are distinguished by an icon prefix, not background fill, so they
+    survive B+W printing. Student worksheets avoid color entirely.
+  - Horizontal rule above each H1 section; no colored section bars.
+  - Bullets over paragraphs wherever possible.
+  - Shorter student tasks may use a 2-column layout to save pages.
+  - Student worksheets follow: task -> instructions -> reminders -> workspace.
+
+Block types (canonical names; legacy aliases accepted, see ALIASES in lesson_common):
+  paragraph, labeled, list, h2, h3, callout, table, cards, columns, group, page_break,
+  phase_header, fill_in, instructions, workspace, checklist
+
+Usage:
+    python render_lesson_html.py lesson.json -o lesson_preview.html
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from html import escape
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lesson_common import (  # noqa: E402
+    DEFAULT_THEME, Theme, CALLOUT_KINDS,
+    btype as _btype, resolve_callout_kind as _resolve_callout_kind,
+    answer_profile, expand_document, build_header, preamble_blocks, coerce_marks,
+    workspace_height, normalize_text, label_text, label_sep, table_row_height,
+    coerce_headers, coerce_rows,
+)
+
+FILL_IN_SIZES = {"short": "6em", "med": "14em", "long": "100%"}
+
+
+def md(text) -> str:
+    t = escape(normalize_text(text), quote=True)
+    t = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", t)
+    t = re.sub(r"(?<!\*)\*(?!\s)(.+?)(?<!\s)\*(?!\*)", r"<i>\1</i>", t)
+    # Preserve line structure: text fields use \n for meaningful line breaks (sub-parts,
+    # multi-paragraph callouts). Collapsing them produced unreadable prose blobs.
+    t = re.sub(r"[ \t]*\n[ \t]*", "<br>", t)
+    return t
+
+
+def answer_space(blk: dict, theme) -> str:
+    """Open writing space — blank whitespace, or ruled lines for lower-grade prose."""
+    h = workspace_height(blk, theme)
+    if blk.get("ruled", theme.ruled_default):
+        gap = float(theme.answer_gap)
+        n = max(2, int(round(h / gap)))
+        lines = f"<div class=\"ansline\" style=\"height:{gap:g}pt\"></div>" * n
+        return f"<div class=\"ans\">{lines}</div>"
+    return f"<div class=\"ans\" style=\"height:{h:g}pt\"></div>"
+
+
+def css(theme: Theme) -> str:
+    """All styling lives in theme.css (next to this script) so the designer can edit it
+    directly. CSS custom properties carry the few themeable values."""
+    css_path = Path(__file__).resolve().parent / "theme.css"
+    base = css_path.read_text(encoding="utf-8") if css_path.exists() else ""
+    if not base:
+        print(f"warning: {css_path} not found — output will be unstyled", file=sys.stderr)
+    try:
+        title_size = float(theme.raw.get("title_size", DEFAULT_THEME["title_size"]))
+    except (TypeError, ValueError):
+        title_size = DEFAULT_THEME["title_size"]
+    try:
+        body_size = float(theme.raw.get("body_size", DEFAULT_THEME["body_size"]))
+    except (TypeError, ValueError):
+        body_size = DEFAULT_THEME["body_size"]
+    root = (":root{"
+            f"--primary:{theme.safe('primary')};--title-color:{theme.safe('title_color')};"
+            f"--text:{theme.safe('text')};--muted:{theme.safe('muted')};"
+            f"--rule:{theme.safe('rule')};--border:{theme.safe('border')};"
+            f"--title-size:{title_size}pt;--body-size:{body_size}pt"
+            "}")
+    return root + "\n" + base
+
+
+def render_block(blk: dict, theme: Theme) -> str:
+    # Adding a block type or text field? Render it in render_lesson_docx.py in
+    # the same commit — the html and docx renderers must emit the same text.
+    t = _btype(blk)
+    if t == "paragraph":
+        return f"<p>{md(blk.get('text', ''))}</p>"
+    if t == "labeled":
+        lbl = label_text(blk)
+        return f"<p><b>{md(lbl)}{label_sep(lbl)}</b> {md(blk.get('text', ''))}</p>"
+    if t == "h2":
+        return f"<div class=\"h2\">{md(blk.get('text', ''))}</div>"
+    if t == "h3":
+        return f"<div class=\"h3\">{md(blk.get('text', ''))}</div>"
+    if t == "instructions":
+        return f"<p class=\"instr\">{md(blk.get('text', ''))}</p>"
+    if t in ("list", "checklist"):
+        cls = ' class="check"' if t == "checklist" else ""
+        tag = "ol" if blk.get("ordered") else "ul"
+        items = "".join(f"<li>{md(i)}</li>" for i in blk.get("items", []))
+        head = (f"<p class=\"listlabel\"><b>{md(label_text(blk))}</b></p>"
+                if blk.get("label") else "")
+        return f"{head}<{tag}{cls}>{items}</{tag}>"
+    if t == "callout":
+        # Models sometimes write "body"/"content" for the content key — tolerate rather than
+        # silently rendering an empty box.
+        text = blk.get("text") or blk.get("body") or blk.get("content") or ""
+        kind = _resolve_callout_kind(blk)
+        icon, klass = CALLOUT_KINDS[kind]
+        label = label_text(blk)
+        head = (f"<div class=\"co-label\"><span class=\"co-icon\">{icon}</span>"
+                f"<b>{md(label)}</b></div>" if label
+                else f"<div class=\"co-label\"><span class=\"co-icon\">{icon}</span></div>")
+        body = f"<p style=\"margin:0\">{md(text)}</p>" if text else ""
+        return f"<div class=\"co {klass}\">{head}{body}</div>"
+    if t == "cards":
+        items = [c if isinstance(c, dict) else {"title": str(c), "text": ""}
+                 for c in blk.get("items", [])]
+        cards = "".join(
+            "<div class=\"card\">"
+            f"<div class=\"card-title\">{md(c.get('title', ''))}</div>"
+            f"<div class=\"card-body\">{md(c.get('text', ''))}</div></div>"
+            for c in items)
+        return f"<div class=\"cards\">{cards}</div>"
+    if t == "fill_in":
+        size = FILL_IN_SIZES.get(str(blk.get("size", "med")).lower(), FILL_IN_SIZES["med"])
+        line = f"<span class=\"fillin\" style=\"width:{size}\"></span>"
+        if blk.get("label"):
+            return f"<p class=\"fillin-row\"><b>{md(label_text(blk))}:</b> {line}</p>"
+        return f"<p class=\"fillin-row\">{line}</p>"
+    if t == "phase_header":
+        mins = blk.get("minutes")
+        right = f"<span class=\"mins\">{md(mins)} min</span>" if mins is not None else ""
+        return (f"<div class=\"h2 phase\"><span>{md(blk.get('name', ''))}</span>"
+                f"{right}</div>")
+    if t == "group":
+        inner = "".join(render_block(b, theme) for b in blk.get("blocks", []))
+        return f"<div style=\"page-break-inside:avoid\">{inner}</div>"
+    if t == "workspace":
+        return answer_space(blk, theme)
+    if t == "labeled_box":
+        label = md(label_text(blk))
+        head = f"<p class=\"listlabel\"><b>{label}</b></p>" if label else ""
+        return f"{head}{answer_space(blk, theme)}"
+    if t == "page_break":
+        return "<hr class=\"pagebreak\">"
+    if t == "table":
+        headers = coerce_headers(blk.get("headers"))
+        head = ""
+        if headers:
+            head = ("<tr>" + "".join(f"<th>{md(str(h).rstrip(': '))}</th>" for h in headers)
+                    + "</tr>")
+        rows = []
+        for r in coerce_rows(blk.get("rows")):
+            # An underscore run is the model writing "blank to fill in" — render it as a
+            # real blank cell, not literal underscores.
+            r = ["" if str(c).strip().strip("_") == "" and "_" in str(c) else c for c in r]
+            full_blank = not any(str(c).strip() for c in r)
+            row_h = table_row_height(blk, theme, full_blank=full_blank)
+            cells = []
+            for c in r:
+                style = ""
+                if not str(c).strip():  # td height acts as a minimum; the row still grows
+                    style = f" style=\"height:{row_h:g}pt\""
+                cells.append(f"<td{style}>{md(c)}</td>")
+            rows.append("<tr>" + "".join(cells) + "</tr>")
+        classes = [] if headers else ["headless"]
+        if blk.get("display") == "large":
+            classes.append("display-large")
+        klass = f" class=\"{' '.join(classes)}\"" if classes else ""
+        return f"<table{klass}>{head}{''.join(rows)}</table>"
+    if t == "columns":
+        left = "".join(render_block(b, theme) for b in blk.get("left", []))
+        right = "".join(render_block(b, theme) for b in blk.get("right", []))
+        return f"<div class=\"cols\"><div>{left}</div><div>{right}</div></div>"
+    if t == "source_card":
+        bits = " · ".join(md(str(blk.get(k))) for k in ("author", "date", "origin")
+                          if blk.get(k))
+        title = md(blk.get("title", ""))
+        excerpt = md(blk.get("excerpt") or blk.get("text") or "")
+        meta = f"<span class=\"sc-meta\"> — {bits}</span>" if bits else ""
+        return (f"<div class=\"sourcecard\"><div class=\"sc-head\"><b>{title}</b>{meta}</div>"
+                f"<div class=\"sc-body\">{excerpt}</div></div>")
+    if t == "fill_table":
+        headers = coerce_headers(blk.get("headers"))
+        row_h = table_row_height(blk, theme, full_blank=True)
+        head = ("<tr>" + "".join(f"<th>{md(h)}</th>" for h in headers) + "</tr>") if headers else ""
+        try:
+            cols = max(1, len(headers) or int(blk.get("cols") or 2))
+        except (TypeError, ValueError):
+            cols = 2
+        cols = min(cols, 12)
+        rows_val = blk.get("rows")
+        if isinstance(rows_val, list):
+            # Mixed rows: a non-empty list renders its cells (a worked example);
+            # an empty list [] renders a blank write-in row.
+            body = ""
+            for r in coerce_rows(rows_val[:50]):
+                cells = r[:cols]
+                cells += [""] * (cols - len(cells))
+                # Underscore runs are write-in blanks, not text (same rule as `table`,
+                # and as the docx fill_table path which forwards through _emit_table).
+                cells = ["" if str(c).strip().strip("_") == "" and "_" in str(c) else c
+                         for c in cells]
+                tds = "".join(
+                    f"<td>{md(c)}</td>" if str(c).strip()
+                    else f"<td style=\"height:{row_h:g}pt\"></td>" for c in cells)
+                body += f"<tr>{tds}</tr>"
+        else:
+            try:
+                n = int(blk.get("blank_rows") or rows_val or 3)
+            except (TypeError, ValueError):
+                n = 3
+            n = min(max(1, n), 50)
+            body = ("<tr>" + (f"<td style=\"height:{row_h:g}pt\"></td>" * cols) + "</tr>") * n
+        return f"<table>{head}{body}</table>"
+    if t == "number_line":
+        lo, hi = blk.get("min", 0), blk.get("max", 10)
+        try:
+            raw_ticks = None if blk.get("ticks") is None else int(blk.get("ticks"))
+        except (TypeError, ValueError):
+            raw_ticks = None
+        # An explicit 0 means "blank line — students partition it themselves": the
+        # bar and its end labels still draw, but with no tick marks at all.
+        is_blank = raw_ticks == 0
+        ticks = 10 if raw_ticks is None else raw_ticks
+        ticks = min(max(1, ticks), 100)
+        marks = coerce_marks(blk.get("marks"))
+        try:
+            lo_f, hi_f = float(lo), float(hi)
+            span = hi_f - lo_f or 1.0
+        except (TypeError, ValueError):
+            lo_f, hi_f, span = 0.0, float(ticks), float(ticks)
+        eps = abs(span) * 0.002
+        marks = [(v, lab) for v, lab in marks
+                 if abs(v - lo_f) > eps and abs(v - hi_f) > eps]
+        tick_html = "".join(
+            f"<span class=\"nl-tick\" style=\"left:{(i/ticks)*100:.2f}%"
+            + (";border-left:none" if is_blank else "") + "\">"
+            f"<span class=\"nl-lab\">{md(lo if i == 0 else hi if i == ticks else '')}</span></span>"
+            for i in range(ticks + 1))
+        mark_html = "".join(
+            f"<span class=\"nl-mark\" style=\"left:{((v-lo_f)/span)*100:.2f}%\"></span>"
+            + (f"<span class=\"nl-mlab\" style=\"left:{((v-lo_f)/span)*100:.2f}%\">{md(lab)}</span>" if lab else "")
+            for v, lab in marks)
+        return (f"<div class=\"numberline\"><div class=\"nl-bar\">{tick_html}{mark_html}"
+                f"</div></div>")
+    # NEVER dump raw JSON into the page — a printed worksheet with {"type": ...} on it is a
+    # blocking print-safety failure (seen in real model output: "list" and "labeled_box").
+    if blk.get("text"):
+        return f"<p>{md(blk.get('text'))}</p>"
+    if blk.get("items"):
+        return "<ul>" + "".join(f"<li>{md(i)}</li>" for i in blk.get("items", [])) + "</ul>"
+    # Unknown type with no renderable content: emit nothing. (No debug comment — the type
+    # string is model-controlled and could contain "-->" to break out of an HTML comment.)
+    return ""
+
+
+def render(data: dict) -> str:
+    data = expand_document(data, data.get("audience", "teacher"))
+    theme = Theme(data.get("theme"))
+    (theme.answer_height, theme.answer_gap,
+     theme.answer_row, theme.ruled_default) = answer_profile(data)
+    theme.student_doc = data.get("audience") == "student"
+    hdr = build_header(data)
+    out = ["<div class=\"hdr\">"]
+    if hdr["eyebrow"]:
+        out.append(f"<div class=\"eyebrow\">{md(hdr['eyebrow'])}</div>")
+    out.append(f"<div class=\"title\">{md(hdr['title'])}</div>")
+    if hdr["meta"]:
+        out.append(f"<div class=\"meta\">{md(hdr['meta'])}</div>")
+    out.append("</div>")
+    if hdr["name_line"]:
+        out.append(f"<p style=\"margin:6pt 0 22pt\">{md(hdr['name_line'])}</p>")
+
+    for blk in preamble_blocks(data):
+        out.append(render_block(blk, theme))
+
+    LIGHT_TYPES = {"paragraph", "labeled", "list", "checklist", "h2", "h3", "callout",
+                   "instructions"}
+    HEAVY_TYPES = {"group", "workspace", "labeled_box"}
+    for section in data.get("sections", []):
+        h1 = (f"<div class=\"h1\"><span>{md(str(section.get('heading', '')).rstrip(': '))}"
+              "</span></div>")
+        # The section heading + leading light blocks + the first atomic item
+        # (group/workspace) print as one unbreakable unit, so an instructions box never
+        # strands above a page break while its first problem starts the next page.
+        blocks = list(section.get("blocks", []))
+        unit = [h1]
+        glued = 0
+        while blocks and glued < 4 and _btype(blocks[0]) in LIGHT_TYPES:
+            unit.append(render_block(blocks.pop(0), theme))
+            glued += 1
+        if blocks and _btype(blocks[0]) in HEAVY_TYPES:
+            unit.append(render_block(blocks.pop(0), theme))
+        if len(unit) > 1:
+            out.append("<div style=\"page-break-inside:avoid\">" + "".join(unit) + "</div>")
+        else:
+            out.append(h1)
+        for blk in blocks:
+            out.append(render_block(blk, theme))
+
+    if data.get("footer_note"):
+        out.append(f"<div class=\"footer\">{md(data['footer_note'])}</div>")
+
+    title = escape(str(data.get("title", "Lesson Plan")), quote=True)
+    return ("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>" + title
+            + "</title><style>" + css(theme) + "</style></head><body><div class=\"page\">"
+            + "".join(out) + "</div></body></html>")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("input", help="lesson JSON file")
+    ap.add_argument("-o", "--output", default="lesson_preview.html")
+    args = ap.parse_args()
+    data = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    Path(args.output).write_text(render(data), encoding="utf-8")
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skill-library/k12-lesson-planning/scripts/theme.css
+++ b/skill-library/k12-lesson-planning/scripts/theme.css
@@ -1,0 +1,93 @@
+/* Copyright 2026 Anthropic, PBC
+   Copyright 2026 Learning Commons
+   SPDX-License-Identifier: Apache-2.0 */
+
+/* Lesson artifact stylesheet — designer-editable.
+   :root vars (--primary, --text, --muted, --rule, --border, --title-size, --body-size)
+   are injected by render_lesson_html.css(). Everything else lives here. */
+
+body{font-family:'Helvetica Neue',Arial,sans-serif;color:var(--text);margin:0;background:#fff}
+.page{max-width:7.1in;margin:0 auto;padding:36pt 24pt;font-size:var(--body-size);line-height:1.55}
+
+/* --- header ------------------------------------------------------------ */
+.hdr{margin-bottom:12pt}
+.eyebrow{color:var(--primary);font-size:9pt;font-weight:700;letter-spacing:1.2pt;text-transform:uppercase}
+.title{color:var(--text);font-size:var(--title-size);font-weight:700;line-height:1.2;letter-spacing:-0.3pt;margin-top:6pt}
+.meta{color:var(--muted);font-size:9pt;margin-top:7pt;line-height:1.5}
+
+/* --- headings ---------------------------------------------------------- */
+.h1{font-size:14pt;font-weight:700;letter-spacing:-0.1pt;border-top:1pt solid var(--rule);
+    padding-top:18pt;margin:24pt 0 12pt;page-break-after:avoid}
+.h2{font-size:12pt;font-weight:700;color:var(--primary);margin:16pt 0 8pt;page-break-after:avoid}
+.h2.phase{display:flex;justify-content:space-between;align-items:baseline}
+.h2 .mins{font-weight:400;font-size:9pt;color:var(--muted)}
+.h3{font-size:10.5pt;font-weight:700;margin:12pt 0 6pt;page-break-after:avoid}
+
+/* --- body -------------------------------------------------------------- */
+p{margin:0 0 8pt}
+.listlabel{margin:10pt 0 2pt}
+ul,ol{margin:0 0 10pt;padding-left:20pt}li{margin:0 0 5pt}
+ul.check{list-style:none;padding-left:4pt}ul.check li:before{content:"\2610  "}
+.instr{color:var(--text);margin:8pt 0 10pt}
+
+/* --- callouts (icon-differentiated, B+W-safe) -------------------------- */
+.co{border:1pt solid var(--border);border-radius:6pt;padding:10pt 12pt;margin:6pt 0 12pt;
+    page-break-inside:avoid}
+.co-label{font-size:9.5pt;margin-bottom:4pt;display:flex;gap:6pt;align-items:baseline}
+.co-icon{font-size:11pt;line-height:1}
+.co.special{border-color:#5BB088}
+.co.task{border-color:#9FB8D8}
+.co.tnote{border-color:#E8C98A}
+.co.snote{border-color:#E8C98A}
+
+/* --- tables ------------------------------------------------------------ */
+table{width:100%;border-collapse:separate;border-spacing:0;margin:4pt 0 14pt;
+      font-size:9pt;line-height:1.45;border:0.6pt solid var(--border);border-radius:6pt;
+      overflow:hidden}
+th,td{border-bottom:0.6pt solid var(--border);border-right:0.6pt solid var(--border);
+      padding:7pt 9pt;text-align:left;vertical-align:top}
+th:last-child,td:last-child{border-right:none}
+tr:last-child td{border-bottom:none}
+tr{page-break-inside:avoid}
+th{background:#F6F8F9;font-weight:700}
+table.headless td:first-child{font-weight:600}
+
+/* --- cards ------------------------------------------------------------- */
+.cards{display:flex;gap:12pt;margin:6pt 0 14pt}
+.card{flex:1;border:0.8pt solid var(--border);border-radius:6pt;padding:10pt 12pt;
+      background:#FAFBFB;page-break-inside:avoid}
+.card-title{font-weight:700;font-size:9.5pt;margin-bottom:4pt}
+.card-body{font-size:9pt}
+
+/* --- worksheet primitives --------------------------------------------- */
+.fillin-row{margin:0 0 10pt}
+.fillin{display:inline-block;border-bottom:0.8pt solid var(--text);height:1.1em;vertical-align:baseline}
+.ans{margin:0 0 14pt}
+.ansline{border-bottom:0.7pt solid #C9CFD4}
+.cols{display:flex;gap:24pt}.cols>div{flex:1;min-width:0}
+
+/* --- registry block types (source_card, number_line) -------------------- */
+.sourcecard{border:0.8pt solid var(--border);border-left:3pt solid var(--primary);
+            border-radius:4pt;padding:9pt 12pt;margin:6pt 0 14pt;page-break-inside:avoid}
+.sourcecard .sc-head{font-size:9.5pt;margin-bottom:5pt}
+.sourcecard .sc-meta{color:var(--muted);font-weight:400}
+.sourcecard .sc-body{font-size:9.5pt;line-height:1.55;white-space:pre-wrap}
+.numberline{margin:10pt 0 18pt;padding:0 8pt}
+.numberline .nl-bar{position:relative;height:28pt;border-top:1.5pt solid var(--text);margin-top:14pt}
+.numberline .nl-tick{position:absolute;top:-6pt;width:0;border-left:1pt solid var(--text);height:10pt}
+.numberline .nl-lab{position:absolute;top:11pt;left:0;transform:translateX(-50%);
+                    font-size:8.5pt;white-space:nowrap}
+.numberline .nl-mark{position:absolute;top:-10pt;width:0;height:0;border-left:5pt solid transparent;
+                     border-right:5pt solid transparent;border-top:8pt solid var(--primary);
+                     transform:translateX(-5pt)}
+.numberline .nl-mlab{position:absolute;top:-22pt;left:0;transform:translateX(-50%);
+                     font-size:8.5pt;font-weight:600;white-space:nowrap;color:var(--primary)}
+
+/* --- misc -------------------------------------------------------------- */
+.pagebreak{page-break-after:always;border:none;margin:0;height:0}
+.footer{color:var(--muted);font-size:8pt;margin-top:20pt}
+
+@media print{.page{padding:0}body{background:#fff}}
+
+/* --- large display tables (K-2 word grids, sort cards) ------------------ */
+table.display-large td{font-size:18pt;font-weight:600;text-align:center;padding:10pt 12pt;letter-spacing:0.5pt}


### PR DESCRIPTION
## Anthropic 官方 K-12 教师技能

来自官方仓库 [anthropics/k12-teacher-skills](https://github.com/anthropics/k12-teacher-skills)(**Apache-2.0**)——目前唯一由 Anthropic 官方出品的 K-12 教师向 Skill。不同于现有的方法论型教案技能,这两个**自带分学科参考 + 渲染脚本,直接产出可编辑 Word 文档**。

| Skill | 一句话 |
|---|---|
| `k12-lesson-planning` | K-12 从零备课:教案 + 学生用材料 + 课堂观察表,分学科(数学/ELA/科学/社会),输出可编辑 Word |
| `k12-lesson-differentiation` | 把已有 K-12 课按学生水平分层:1 份教师分层方案 + 3 份学生分层材料,全为可编辑 Word |

### 互斥路由(已在中文 description 中保留)
- **新建**一节课 → `k12-lesson-planning`(即使要分层材料,也在该包内一并产出,**不要**再调 differentiation)
- **改造已有**课 → `k12-lesson-differentiation`
- 两者都**不用于**批改 / 量规 / 测验 / 课标检索

### 对齐规范
- `category: 教学辅导`;`description` 改写为中文(含触发词),并**完整保留原有互斥路由说明**以免重复触发
- **完整保留各自 `LICENSE` 与 `references/NOTICE`**(含 Common Core State Standards 公共许可声明)—— Apache-2.0 要求
- 保留 `scripts/`(render_lesson_docx / render_documents 等)与分学科 `references/`
- `类型=收集`,引用官方上游;README 归入已有分组「🧑‍🏫 教育 · 教案与教学设计」并置顶

### 说明:与现有技能的关系(不冲突)
现有 `backwards-design-unit-planner` / `differentiation-adapter`(GarethManning)是**循证方法论**型,偏单元级设计与理据;这两个官方技能是**成品产出**型,偏 K-12 课时级、直接交付 Word 材料。定位互补,建议并存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)