### PR TITLE
feat(skill-library): 新增 packs.json 技能包定义

### DIFF
--- a/skill-library/README.md
+++ b/skill-library/README.md
@@ -238,3 +238,12 @@ description: >-
 
 完整贡献流程见仓库根目录 [README.md 的「贡献」一节](../README.md#贡献)。
 
+
+## 平台元数据文件
+
+技能之外,`skill-library/` 里还有两个给展示站与 Innoskill 平台读的 JSON,**新增或调整技能时顺手维护**:
+
+| 文件 | 内容 | 谁用 |
+|---|---|---|
+| `scenarios.json` | 五个提问式场景(星系)、每个技能的场景归属与「试试这句话」示例、`featured` 精选名单(星图只展示这一组) | 星图首页 |
+| `packs.json` | 技能包:`{ id, name, description, icon, subject, skills[] }`,`icon` 用 [lucide](https://lucide.dev/icons) 图标名,`skills` 里的 id 必须是本目录下已存在的技能 | Innoskill「技能包」/ InnoAgent 技能仓库 |

--- a/skill-library/packs.json
+++ b/skill-library/packs.json
@@ -1,0 +1,79 @@
+{
+  "packs": [
+    {
+      "id": "lesson-prep",
+      "name": "备课技能包",
+      "description": "从课标到教案:单元逆向设计、显性教学序列、分层适配与形成性评估,把一节课从零备到能上。",
+      "icon": "book-open",
+      "subject": "跨学科",
+      "skills": [
+        "k12-lesson-planning",
+        "backwards-design-unit-planner",
+        "explicit-instruction-sequence-builder",
+        "differentiation-adapter",
+        "formative-assessment-technique-selector",
+        "scope-and-sequence-designer"
+      ]
+    },
+    {
+      "id": "courseware",
+      "name": "课件与讲解技能包",
+      "description": "一句话出动画网页课件、PPT、信息图与配图;立体几何、圆锥曲线直接生成可交互解题页。",
+      "icon": "presentation",
+      "subject": "跨学科",
+      "skills": [
+        "frontend-slides",
+        "pptx",
+        "smart-illustrator",
+        "baoyu-infographic",
+        "baoyu-slide-deck",
+        "edu-solid-geometry",
+        "edu-analytic-geometry"
+      ]
+    },
+    {
+      "id": "grading",
+      "name": "批改与评价技能包",
+      "description": "量规批改、Word 原生批注、考题逆向拆考点、按学生水平分层出材料,形成教-评-改闭环。",
+      "icon": "square-check",
+      "subject": "跨学科",
+      "skills": [
+        "homework-grader",
+        "comment-on-docx",
+        "Exam2Knowledge",
+        "k12-lesson-differentiation",
+        "docx"
+      ]
+    },
+    {
+      "id": "self-study",
+      "name": "自学辅导技能包",
+      "description": "给思路不给答案:苏格拉底式讲题、数学家教、通用学科家教,建立真正的理解。",
+      "icon": "graduation-cap",
+      "subject": "跨学科",
+      "skills": [
+        "math-tutor",
+        "socratic-tutor",
+        "tutor",
+        "learning-opportunities"
+      ]
+    },
+    {
+      "id": "research",
+      "name": "教研科研技能包",
+      "description": "从选题到成稿:文献检索与引用校验、多视角深度研究报告、系统综述与文献图谱、资料格式转换。",
+      "icon": "flask-conical",
+      "subject": "跨学科",
+      "skills": [
+        "storm-research",
+        "paper-lookup",
+        "citation-management",
+        "markitdown",
+        "education-topic-decomposition",
+        "education-literature-map",
+        "education-systematic-review-preparation",
+        "scholar-distill"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 变更

- `skill-library/packs.json`:5 个示例技能包(备课 / 课件与讲解 / 批改与评价 / 自学辅导 / 教研科研),共 30 个技能引用,全部校验为已收录 id
- `skill-library/README.md`:补「平台元数据文件」一节,说明 `scenarios.json` 与 `packs.json` 的用途和维护规则

## 为什么

Innoskill 第二期给 InnoAgent 技能仓库提供「技能包」与「一键添加整包」,包的定义属于内容,放 hub 仓库由内容维护者管;Innoskill 只同步、分发。

名单和分组是产品决策,这里只是让链路先跑通,欢迎直接改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)